### PR TITLE
网络不通 无法下载完整的 arthas zip，增加可配置性

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.github.wangji92.arthas.plugin</id>
     <name>arthas idea</name>
-    <version>2.26</version>
+    <version>2.27</version>
     <vendor email="983433479@qq.com" url="https://github.com/WangJi92/arthas-idea-plugin">汪小哥</vendor>
 
     <description><![CDATA[
@@ -42,6 +42,13 @@
     ]]></description>
 
     <change-notes><![CDATA[
+     <p>2.27-RELEASE</p>
+      <ul>
+        <li>support can be configured to download arthas zip full package address,default address: https://arthas.aliyun.com/download/latest_version?mirror=aliyun</li>
+      </ul>
+       <ul>
+        <li>支持可以配置下载arthas zip 完整包地址</li>
+      </ul>
     <p>2.26-RELEASE</p>
       <ul>
         <li><a href="https://www.yuque.com/wangji-yunque/ikhsmq/lyevb2">Support Hot Swap Retransform Command</a></li>

--- a/resources/template/arthas-idea-plugin-hot-swap.sh
+++ b/resources/template/arthas-idea-plugin-hot-swap.sh
@@ -3,6 +3,9 @@
 TARGET_PID=
 SELECT_VALUE=${arthasIdeaPluginApplicationName}
 
+#arthas package zip download url = https://arthas.aliyun.com/download/latest_version?mirror=aliyun
+ARTHAS_PACKAGE_ZIP_DOWNLOAD_URL=${arthasPackageZipDownloadUrl}
+
 # SYNOPSIS
 #   rreadlink <fileOrDirPath>
 # DESCRIPTION
@@ -123,6 +126,9 @@ select_pid() {
       echo "  [$index]: ${process}"
     fi
   done
+  echo " "
+  echo "$(echo $(tput setaf 1) 请手动选择进程或者idea 预先配置jps -l 工程名称自动执行$(tput sgr0))"
+  echo " "
 
   read choice
 
@@ -168,10 +174,17 @@ installArthas() {
     mkdir -p $HOME/opt/arthas || return 1
   fi
   # download arthas
-  if [ ! -f "$HOME/opt/arthas/as.sh" ]; then
-    banner_simple "arthas idea plugin download arthas $HOME/opt/arthas/as.sh"
-    curl -Lk https://arthas.aliyun.com/as.sh -o $HOME/opt/arthas/as.sh || return 1
-    chmod +x $HOME/opt/arthas/as.sh || return 1
+
+  if [ ! -f "$HOME/opt/arthas/arthas-packaging-latest-version-bin.zip" ]; then
+    local temp_target_lib_zip="$HOME/opt/arthas/arthas-packaging-latest-version-bin.zip"
+    echo "arthas idea plugin download arthas zip package ${temp_target_lib_zip}"
+    echo " "
+    echo "$(echo $(tput setaf 1)如果内网访问不到 https://arthas.aliyun.com/download/latest_version?mirror=aliyun $(tput sgr0))"
+    echo "$(echo $(tput setaf 1)idea设置能够访问的完整包的下载地址 或者直接下载解压到服务器 $HOME/opt/arthas 目录 $(tput sgr0))"
+    echo " "
+    curl  -Lk "${ARTHAS_PACKAGE_ZIP_DOWNLOAD_URL}" -o  "${temp_target_lib_zip}" || retrun 1
+    cd "$HOME/opt/arthas" && unzip -o "${temp_target_lib_zip}"
+    chmod +x "$HOME/opt/arthas/as.sh" || return 1
   fi
 }
 # xxxClassBase64Str|xxxClassPath,xxxClass2Base64Str|xxxClass2Path

--- a/resources/template/arthas-idea-plugin-hot-swap.sh
+++ b/resources/template/arthas-idea-plugin-hot-swap.sh
@@ -4,7 +4,7 @@ TARGET_PID=
 SELECT_VALUE=${arthasIdeaPluginApplicationName}
 
 #arthas package zip download url = https://arthas.aliyun.com/download/latest_version?mirror=aliyun
-ARTHAS_PACKAGE_ZIP_DOWNLOAD_URL=${arthasPackageZipDownloadUrl}
+ARTHAS_PACKAGE_ZIP_DOWNLOAD_URL="${arthasPackageZipDownloadUrl}"
 
 # SYNOPSIS
 #   rreadlink <fileOrDirPath>
@@ -175,12 +175,14 @@ installArthas() {
   fi
   # download arthas
 
-  if [ ! -f "$HOME/opt/arthas/arthas-packaging-latest-version-bin.zip" ]; then
+  if [ ! -f "$HOME/opt/arthas/arthas-agent.jar" ]; then
+    # 这里选择判断是否下载zip 包 没有使用 arthas-packaging-latest-version-bin.zip 这个名词 由于手动上传解压到当前目录名词可能不一致，选择一个中性的判断比较灵活
     local temp_target_lib_zip="$HOME/opt/arthas/arthas-packaging-latest-version-bin.zip"
-    echo "arthas idea plugin download arthas zip package ${temp_target_lib_zip}"
+    echo "arthas idea plugin download arthas zip package ${temp_target_lib_zip} download url=${ARTHAS_PACKAGE_ZIP_DOWNLOAD_URL}"
     echo " "
-    echo "$(echo $(tput setaf 1)如果内网访问不到 https://arthas.aliyun.com/download/latest_version?mirror=aliyun $(tput sgr0))"
-    echo "$(echo $(tput setaf 1)idea设置能够访问的完整包的下载地址 或者直接下载解压到服务器 $HOME/opt/arthas 目录 $(tput sgr0))"
+    echo "$(echo $(tput setaf 1)如果网络无法访问 https://arthas.aliyun.com/download/latest_version?mirror=aliyun $(tput sgr0))"
+    echo "$(echo $(tput setaf 1)idea设置网络可以访问的arthas 完整zip包的下载地址 或者直接下载解压到服务器 $HOME/opt/arthas 目录 $(tput sgr0))"
+    echo "$(echo $(tput setaf 1)如果配置的是oss 存储,arthas 命令 other分组下面 Local File Upload To Oss命令可以上传文件 有效期1年,配置到arthas zip包地址$(tput sgr0))"
     echo " "
     curl  -Lk "${ARTHAS_PACKAGE_ZIP_DOWNLOAD_URL}" -o  "${temp_target_lib_zip}" || retrun 1
     cd "$HOME/opt/arthas" && unzip -o "${temp_target_lib_zip}"

--- a/src/com/github/wangji92/arthas/plugin/action/arthas/ArthasHotRedefineCommandAction.java
+++ b/src/com/github/wangji92/arthas/plugin/action/arthas/ArthasHotRedefineCommandAction.java
@@ -187,6 +187,7 @@ public class ArthasHotRedefineCommandAction extends AnAction implements DumbAwar
                 params.put("arthasIdeaPluginRedefineCommand", arthasIdeaPluginRedefineCommand);
                 params.put("arthasIdeaPluginApplicationName", selectProjectName);
                 params.put("deleteClassFile", deleteClassFile);
+                params.put("arthasPackageZipDownloadUrl",settings.arthasPackageZipDownloadUrl);
 
 
                 String redefineSh = StringUtils.stringSubstitutor("/template/arthas-idea-plugin-hot-swap.sh", params);

--- a/src/com/github/wangji92/arthas/plugin/action/arthas/LocalFileUploadToOssAction.java
+++ b/src/com/github/wangji92/arthas/plugin/action/arthas/LocalFileUploadToOssAction.java
@@ -78,7 +78,7 @@ public class LocalFileUploadToOssAction extends AnAction {
                 oss = AliyunOssUtils.buildOssClient(project);
                 String filePathKey = settings.directoryPrefix + UUID.randomUUID().toString();
                 String urlEncodeKeyPath = AliyunOssUtils.putFile(oss, settings.bucketName, filePathKey, selectVirtualFile.getInputStream());
-                String presignedUrl = AliyunOssUtils.generatePresignedUrl(oss, settings.bucketName, urlEncodeKeyPath, new Date(System.currentTimeMillis() + 3600L * 1000));
+                String presignedUrl = AliyunOssUtils.generatePresignedUrl(oss, settings.bucketName, urlEncodeKeyPath, new Date(System.currentTimeMillis() + 24*365*3600L * 1000));
                 String command = String.format(OSS_UP_LOAD_FILE, presignedUrl, selectVirtualFile.getName());
                 ClipboardUtils.setClipboardString(command);
                 NotifyUtils.notifyMessage(project, "直接到目标服务器任意路径 粘贴脚本执行下载文件");

--- a/src/com/github/wangji92/arthas/plugin/constants/ArthasCommandConstants.java
+++ b/src/com/github/wangji92/arthas/plugin/constants/ArthasCommandConstants.java
@@ -78,4 +78,9 @@ public interface ArthasCommandConstants {
      * 获取spring 所有的环境变量的表达式
      */
     String SPRING_ALL_PROPERTY = "%s '%s,#allProperties={},#standardServletEnvironment=#propertySourceIterator=#springContext.getEnvironment(),#propertySourceIterator=#standardServletEnvironment.getPropertySources().iterator(),#propertySourceIterator.{#key=#this.getName(),#allProperties.add(\"                \"),#allProperties.add(\"------------------------- name:\"+#key),#this.getSource() instanceof java.util.Map ?#this.getSource().entrySet().iterator.{#key=#this.key,#allProperties.add(#key+\"=\"+#standardServletEnvironment.getProperty(#key))}:#{}},#allProperties'";
+
+    /**
+     * 默认的 arthas zip 完整包的下载地址
+     */
+    String DEFAULT_ARTHAS_PACKAGE_ZIP_DOWNLOAD_URL = "https://arthas.aliyun.com/download/latest_version?mirror=aliyun";
 }

--- a/src/com/github/wangji92/arthas/plugin/setting/AppSettingsState.java
+++ b/src/com/github/wangji92/arthas/plugin/setting/AppSettingsState.java
@@ -13,8 +13,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static com.github.wangji92.arthas.plugin.constants.ArthasCommandConstants.AT;
-import static com.github.wangji92.arthas.plugin.constants.ArthasCommandConstants.DEFAULT_SPRING_CONTEXT_SETTING;
+import static com.github.wangji92.arthas.plugin.constants.ArthasCommandConstants.*;
 
 /**
  * Supports storing the application settings in a persistent way.
@@ -137,7 +136,7 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
     /**
      * 剪切板
      */
-    public boolean hotRedefineClipboard = false;
+    public boolean hotRedefineClipboard = true;
 
     /**
      * redis 的链接地址
@@ -164,6 +163,11 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
      */
     public Integer redisCacheKeyTtl = 60 * 60 * 2;
 
+    /**
+     * 默认下载地址
+     */
+    public String arthasPackageZipDownloadUrl = DEFAULT_ARTHAS_PACKAGE_ZIP_DOWNLOAD_URL;
+
 
     public static AppSettingsState getInstance(@NotNull Project project) {
         AppSettingsState appSettingsState = ServiceManager.getService(project, AppSettingsState.class);
@@ -175,7 +179,26 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
 
         // 检测全局的redis 配置
         checkGlobalRedisAndSettingCurrentProjectIfEmpty(appSettingsState);
+
+        // 检查全局的 arthas zip 包的下载地址
+        checkGlobalArthasPackageZipDownloadUrl(appSettingsState);
         return appSettingsState;
+    }
+
+
+    /**
+     * 设置一个 arthas zip 包的下载地址 （部分内网无法访问需要自己下载上传）
+     *
+     * @param appSettingsState
+     */
+    private static void checkGlobalArthasPackageZipDownloadUrl(AppSettingsState appSettingsState) {
+        String globalArthasPackageZipDownloadUrl = PropertiesComponentUtils.getValue("arthasPackageZipDownloadUrl");
+        if (StringUtils.isNotBlank(appSettingsState.arthasPackageZipDownloadUrl) && !DEFAULT_ARTHAS_PACKAGE_ZIP_DOWNLOAD_URL.equalsIgnoreCase(appSettingsState.arthasPackageZipDownloadUrl)) {
+            return;
+        }
+        if (StringUtils.isNotBlank(globalArthasPackageZipDownloadUrl) && !DEFAULT_ARTHAS_PACKAGE_ZIP_DOWNLOAD_URL.equalsIgnoreCase(globalArthasPackageZipDownloadUrl)) {
+            appSettingsState.arthasPackageZipDownloadUrl = globalArthasPackageZipDownloadUrl;
+        }
     }
 
     /**

--- a/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.form
+++ b/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="930" height="696"/>
+      <xy x="20" y="20" width="1046" height="696"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -645,7 +645,8 @@
                   <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Arthas Package Zip Address"/>
+                  <text value="Arthas Package Zip Download Url"/>
+                  <toolTipText value="如果内网无法访问阿里云的地址 可以手动指定 完整包的地址"/>
                 </properties>
               </component>
               <component id="9325e" class="javax.swing.JTextField" binding="arthasPackageZipDownloadUrlTextField">
@@ -656,6 +657,14 @@
                 </constraints>
                 <properties>
                   <text value=""/>
+                </properties>
+              </component>
+              <component id="89eb7" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="7" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="内网无法访问指定完整包下载地址"/>
                 </properties>
               </component>
             </children>

--- a/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.form
+++ b/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="855" height="664"/>
+      <xy x="20" y="20" width="930" height="696"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -194,7 +194,7 @@
               </component>
             </children>
           </grid>
-          <grid id="f4b0a" binding="hotRedefineSettingPane" layout-manager="GridLayoutManager" row-count="8" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="f4b0a" binding="hotRedefineSettingPane" layout-manager="GridLayoutManager" row-count="9" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="10" left="10" bottom="10" right="10"/>
             <constraints>
               <tabbedpane title="Hot Swap Setting"/>
@@ -213,7 +213,7 @@
               </component>
               <vspacer id="d59d5">
                 <constraints>
-                  <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                  <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
               <component id="bf4f" class="javax.swing.JRadioButton" binding="clipboardRadioButton">
@@ -640,6 +640,24 @@
                   </component>
                 </children>
               </grid>
+              <component id="e9096" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Arthas Package Zip Address"/>
+                </properties>
+              </component>
+              <component id="9325e" class="javax.swing.JTextField" binding="arthasPackageZipDownloadUrlTextField">
+                <constraints>
+                  <grid row="7" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <text value=""/>
+                </properties>
+              </component>
             </children>
           </grid>
         </children>

--- a/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.java
+++ b/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.java
@@ -23,6 +23,7 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 
 import static com.github.wangji92.arthas.plugin.constants.ArthasCommandConstants.AT;
+import static com.github.wangji92.arthas.plugin.constants.ArthasCommandConstants.DEFAULT_ARTHAS_PACKAGE_ZIP_DOWNLOAD_URL;
 
 /**
  * https://jetbrains.org/intellij/sdk/docs/reference_guide/settings_guide.html 属性配置 参考
@@ -184,6 +185,11 @@ public class AppSettingsPage implements Configurable {
      */
     private JSpinner redisCacheKeyTtl;
 
+    /**
+     * arthas zip 信息的地址
+     */
+    private JTextField arthasPackageZipDownloadUrlTextField;
+
 
     @Nls(capitalization = Nls.Capitalization.Title)
     @Override
@@ -289,7 +295,8 @@ public class AppSettingsPage implements Configurable {
                 || hotRedefineDeleteFileRadioButton.isSelected() != settings.hotRedefineDelete
                 || redefineBeforeCompileRadioButton.isSelected() != settings.redefineBeforeCompile
                 || printConditionExpressRadioButton.isSelected() != settings.printConditionExpress
-                || manualSelectPidRadioButton.isSelected() != settings.manualSelectPid;
+                || manualSelectPidRadioButton.isSelected() != settings.manualSelectPid
+                || !arthasPackageZipDownloadUrlTextField.getText().equalsIgnoreCase(settings.arthasPackageZipDownloadUrl);
 
         if (modify) {
             return modify;
@@ -355,6 +362,12 @@ public class AppSettingsPage implements Configurable {
         settings.hotRedefineDelete = hotRedefineDeleteFileRadioButton.isSelected();
         settings.redefineBeforeCompile = redefineBeforeCompileRadioButton.isSelected();
         settings.printConditionExpress = printConditionExpressRadioButton.isSelected();
+        settings.arthasPackageZipDownloadUrl = arthasPackageZipDownloadUrlTextField.getText();
+
+        if (!settings.arthasPackageZipDownloadUrl.equalsIgnoreCase(DEFAULT_ARTHAS_PACKAGE_ZIP_DOWNLOAD_URL)) {
+            // 设置到全局
+            PropertiesComponentUtils.setValue("arthasPackageZipDownloadUrl", arthasPackageZipDownloadUrlTextField.getText());
+        }
         if (clipboardRadioButton.isSelected()) {
             settings.hotRedefineClipboard = true;
             settings.aliYunOss = false;
@@ -518,6 +531,9 @@ public class AppSettingsPage implements Configurable {
         }
         springContextGlobalSettingRadioButton.setSelected(settings.springContextGlobalSetting);
         ossGlobalSettingRadioButton.setSelected(settings.ossGlobalSetting);
+
+        // 设置远程的下载地址
+        arthasPackageZipDownloadUrlTextField.setText(settings.arthasPackageZipDownloadUrl);
         initEvent();
     }
 


### PR DESCRIPTION
网络不通 无法下载完整的 arthas zip 包 https://arthas.aliyun.com/download/latest_version?mirror=aliyun
arthas idea 支持配置完整的zip 包地址，方便热更新时可以手动上传文件  ~/opt/arthas 目录 或者配置一个 可以访问下载完整zip 包的地址 
![image](https://user-images.githubusercontent.com/20874972/114424411-a94d4c80-9bea-11eb-8eec-27575f0648d8.png)
