### PR TITLE
快捷命令中增加反射修改字段的变量+GC 命令

### DIFF
--- a/src/com/github/wangji92/arthas/plugin/common/enums/ShellScriptCommandEnum.java
+++ b/src/com/github/wangji92/arthas/plugin/common/enums/ShellScriptCommandEnum.java
@@ -231,7 +231,7 @@ public enum ShellScriptCommandEnum implements EnumCodeMsg<String> {
             + " --express '#field=instances[0].getClass()"
             + ".getDeclaredField(\"" + ShellScriptVariableEnum.EXECUTE_INFO.getCode() + "\"),#field.setAccessible(true),"
             + "#field.set(instances[0]," + ShellScriptVariableEnum.DEFAULT_FIELD_VALUE.getCode() + ")'",
-            "vmtool get instance invoke method field,you can edit express params,find first instance") {
+            "vmtool 获取到实例后通过反射修改字段的值,需要编辑设置的值的信息") {
         @Override
         public boolean support(CommandContext context) {
             if (OgnlPsUtils.isAnonymousClass(context.getPsiElement())) {
@@ -242,6 +242,41 @@ public enum ShellScriptCommandEnum implements EnumCodeMsg<String> {
                 return false;
             }
             return OgnlPsUtils.isNonStaticField(context.getPsiElement()) && !OgnlPsUtils.isFinalField(context.getPsiElement());
+        }
+
+        @Override
+        public String getScCommand(CommandContext context) {
+            String className = OgnlPsUtils.getCommonOrInnerOrAnonymousClassName(context.getPsiElement());
+            return String.join(" ", "sc", "-d", className);
+        }
+
+        @Override
+        public String getArthasCommand(CommandContext context) {
+            return context.getCommandCode(this);
+        }
+    },
+    /**
+     * 通过反射设置变量
+     * vmtool -x 3 --action getInstances --className com.xxx.cache.CacheAspect  --express '#field=instances[0].getClass().getDeclaredField("cacheEnabled"),#field.setAccessible(true),#field.set(instances[0],false)'  -c 3bd94634
+     */
+    VM_TOOL_INVOKE_REFLECT_FINAL_FIELD("vmtool -x "
+            + ShellScriptVariableEnum.PROPERTY_DEPTH.getCode() + " "
+            + "--action getInstances --className "
+            + ShellScriptVariableEnum.CLASS_NAME.getCode() + " "
+            + " --express '#field=instances[0].getClass()"
+            + ".getDeclaredField(\"" + ShellScriptVariableEnum.EXECUTE_INFO.getCode() + "\"),#modifiers=#field.getClass().getDeclaredField(\"modifiers\"),#modifiers.setAccessible(true),#modifiers.setInt(#field,#field.getModifiers() & ~@java.lang.reflect.Modifier@FINAL),#field.setAccessible(true),"
+            + "#field.set(instances[0]," + ShellScriptVariableEnum.DEFAULT_FIELD_VALUE.getCode() + ")'",
+            "vmtool 获取到实例后通过反射修改字段的值,需要编辑设置的值的信息") {
+        @Override
+        public boolean support(CommandContext context) {
+            if (OgnlPsUtils.isAnonymousClass(context.getPsiElement())) {
+                return false;
+            }
+            // 构造方法不支持
+            if (OgnlPsUtils.isConstructor(context.getPsiElement())) {
+                return false;
+            }
+            return OgnlPsUtils.isNonStaticField(context.getPsiElement()) && OgnlPsUtils.isFinalField(context.getPsiElement());
         }
 
         @Override

--- a/src/com/github/wangji92/arthas/plugin/common/enums/ShellScriptCommandEnum.java
+++ b/src/com/github/wangji92/arthas/plugin/common/enums/ShellScriptCommandEnum.java
@@ -220,6 +220,41 @@ public enum ShellScriptCommandEnum implements EnumCodeMsg<String> {
             return context.getCommandCode(this);
         }
     },
+    /**
+     * 通过反射设置变量
+     * vmtool -x 3 --action getInstances --className com.xxx.cache.CacheAspect  --express '#field=instances[0].getClass().getDeclaredField("cacheEnabled"),#field.setAccessible(true),#field.set(instances[0],false)'  -c 3bd94634
+     */
+    VM_TOOL_INVOKE_REFLECT_FIELD("vmtool -x "
+            + ShellScriptVariableEnum.PROPERTY_DEPTH.getCode() + " "
+            + "--action getInstances --className "
+            + ShellScriptVariableEnum.CLASS_NAME.getCode() + " "
+            + " --express '#field=instances[0].getClass()"
+            + ".getDeclaredField(\"" + ShellScriptVariableEnum.EXECUTE_INFO.getCode() + "\"),#field.setAccessible(true),"
+            + "#field.set(instances[0]," + ShellScriptVariableEnum.DEFAULT_FIELD_VALUE.getCode() + ")'",
+            "vmtool get instance invoke method field,you can edit express params,find first instance") {
+        @Override
+        public boolean support(CommandContext context) {
+            if (OgnlPsUtils.isAnonymousClass(context.getPsiElement())) {
+                return false;
+            }
+            // 构造方法不支持
+            if (OgnlPsUtils.isConstructor(context.getPsiElement())) {
+                return false;
+            }
+            return OgnlPsUtils.isNonStaticField(context.getPsiElement()) && !OgnlPsUtils.isFinalField(context.getPsiElement());
+        }
+
+        @Override
+        public String getScCommand(CommandContext context) {
+            String className = OgnlPsUtils.getCommonOrInnerOrAnonymousClassName(context.getPsiElement());
+            return String.join(" ", "sc", "-d", className);
+        }
+
+        @Override
+        public String getArthasCommand(CommandContext context) {
+            return context.getCommandCode(this);
+        }
+    },
     VM_TOOL_SPRING_ENV("vmtool -x "
             + ShellScriptVariableEnum.PROPERTY_DEPTH.getCode() + " "
             + "--action getInstances --className org.springframework.core.env.ConfigurableEnvironment "

--- a/src/com/github/wangji92/arthas/plugin/common/enums/ShellScriptConstantEnum.java
+++ b/src/com/github/wangji92/arthas/plugin/common/enums/ShellScriptConstantEnum.java
@@ -27,6 +27,16 @@ public enum ShellScriptConstantEnum implements EnumCodeMsg<String> {
     DASHBOARD_N_1("dashboard -n 1", "dashboard info"),
     SYS_PROP_ENV("sysprop;sysenv;", "sysprop and sysenv"),
     VM_OPTION("vmoption;", "display, and update the vm diagnostic options. vmoption PrintGCDetails true;"),
+    /**
+     * https://mp.weixin.qq.com/s/GF3C7RcEPV0f1hDah6CJPA
+     */
+    VM_OPTION_PRINT_GC("vmoption PrintGC true", " print gc info"),
+    VM_OPTION_PRINT_GC_DETAIL("vmoption PrintGCDetails true", " print gc details"),
+    VM_OPTION_PRINT_GC_DATE("vmoption PrintGCDateStamps true", " print gc time"),
+    VM_OPTION_PRINT_GC_BEFORE_DUMP("vmoption HeapDumpBeforeFullGC true", "打开HeapDumpBeforeFullGC开关，可以在GC前生成heapdump文件"),
+    VM_OPTION_PRINT_GC_AFTER_DUMP("vmoption HeapDumpAfterFullGC true", "打开HeapDumpAfterFullGC开关，可以在GC结束后生成heapdump文件"),
+    VM_OPTION_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC("vmoption PrintClassHistogramBeforeFullGC true", "打开PrintClassHistogramBeforeFullGC开关，可以在GC前打印类直方图"),
+    VM_OPTION_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC("vmoption PrintClassHistogramAfterFullGC true", "打开PrintClassHistogramAfterFullGC开关，可以在GC结束后打印类直方图"),
     PERF_COUNTER("perfcounter -d", "display the perf counter information.");
 
 


### PR DESCRIPTION
## 快捷静态命令中增加 常量命令 GC 相关的参数
* [十万火急！不重启应用怎么查GC日志？Arthas来搞定](https://mp.weixin.qq.com/s/GF3C7RcEPV0f1hDah6CJPA)

## 快捷动态命令增加 vmtool 反射修改实例非静态字段的值
![image](https://user-images.githubusercontent.com/20874972/127734741-bb10eded-91b6-495c-96d3-3d46fe68d3bb.png)

```bash
vmtool -x 4 --action getInstances --className com.wangji92.arthas.plugin.demo.controller.CommonController  --express '#field=instances[0].getClass().getDeclaredField("FINAL_VALUE"),#modifiers=#field.getClass().getDeclaredField("modifiers"),#modifiers.setAccessible(true),#modifiers.setInt(#field,#field.getModifiers() & ~@java.lang.reflect.Modifier@FINAL),#field.setAccessible(true),#field.set(instances[0]," 3333")' -c  18b4aac2
```
