### PR TITLE
快捷命令增加 可以手动输入 sc -d  获取classloader的逻辑

### DIFF
--- a/src/com/github/wangji92/arthas/plugin/common/combox/CustomDefaultListCellRenderer.java
+++ b/src/com/github/wangji92/arthas/plugin/common/combox/CustomDefaultListCellRenderer.java
@@ -14,9 +14,12 @@ public class CustomDefaultListCellRenderer extends DefaultListCellRenderer {
 
     private JComboBox comboBox;
 
+    private JLabel tipLabel;
 
-    public CustomDefaultListCellRenderer(JComboBox shellScriptComboBox) {
+
+    public CustomDefaultListCellRenderer(JComboBox shellScriptComboBox, JLabel tipLabel) {
         this.comboBox = shellScriptComboBox;
+        this.tipLabel = tipLabel;
     }
 
     @Override
@@ -30,6 +33,9 @@ public class CustomDefaultListCellRenderer extends DefaultListCellRenderer {
         }
         if (isSelected) {
             comboBox.setToolTipText(tipText);
+            if (tipLabel != null) {
+                tipLabel.setText(tipText);
+            }
         }
         setToolTipText(tipText);
         return this;

--- a/src/com/github/wangji92/arthas/plugin/ui/ArthasShellScriptCommandDialog.form
+++ b/src/com/github/wangji92/arthas/plugin/ui/ArthasShellScriptCommandDialog.form
@@ -1,173 +1,199 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.github.wangji92.arthas.plugin.ui.ArthasShellScriptCommandDialog">
-  <grid id="cbd77" binding="contentPane" layout-manager="FormLayout">
-    <rowspec value="center:9px:noGrow"/>
-    <rowspec value="top:3dlu:noGrow"/>
-    <rowspec value="center:d:grow"/>
-    <rowspec value="top:3dlu:noGrow"/>
-    <rowspec value="center:d:grow"/>
-    <rowspec value="top:3dlu:noGrow"/>
-    <rowspec value="center:d:grow"/>
-    <rowspec value="top:3dlu:noGrow"/>
-    <rowspec value="center:d:grow"/>
-    <rowspec value="top:3dlu:noGrow"/>
-    <rowspec value="center:d:grow"/>
-    <rowspec value="top:3dlu:noGrow"/>
-    <rowspec value="center:d:grow"/>
-    <rowspec value="top:3dlu:noGrow"/>
-    <rowspec value="center:d:grow"/>
-    <rowspec value="top:3dlu:noGrow"/>
-    <rowspec value="center:d:grow"/>
-    <rowspec value="top:3dlu:noGrow"/>
-    <rowspec value="center:d:grow"/>
-    <rowspec value="top:3dlu:noGrow"/>
-    <rowspec value="center:d:grow"/>
-    <rowspec value="top:3dlu:noGrow"/>
-    <rowspec value="center:max(d;4px):noGrow"/>
-    <rowspec value="top:3dlu:noGrow"/>
-    <rowspec value="center:max(d;4px):noGrow"/>
-    <colspec value="fill:max(d;4px):noGrow"/>
-    <colspec value="left:4dlu:noGrow"/>
-    <colspec value="fill:846px:grow"/>
-    <colspec value="fill:118px:noGrow"/>
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="11" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
-      <xy x="48" y="276" width="1014" height="333"/>
+      <xy x="48" y="276" width="982" height="379"/>
     </constraints>
     <properties/>
     <border type="etched"/>
     <children>
-      <component id="fdea2" class="javax.swing.JComboBox" binding="shellScriptComboBox">
-        <constraints>
-          <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="7" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="100" height="23"/>
-          </grid>
-          <forms defaultalign-horz="false" defaultalign-vert="false"/>
-        </constraints>
-        <properties>
-          <editable value="true"/>
-        </properties>
-      </component>
       <component id="445ea" class="javax.swing.JLabel" binding="dyTipLabel">
         <constraints>
-          <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-          <forms/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value=""/>
         </properties>
       </component>
-      <component id="3ca4d" class="javax.swing.JComboBox" binding="commonShellScriptComboBox" default-binding="true">
-        <constraints>
-          <grid row="14" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="438" height="27"/>
-          </grid>
-          <forms/>
-        </constraints>
-        <properties>
-          <editable value="true"/>
-        </properties>
-      </component>
       <component id="6e316" class="javax.swing.JLabel" binding="constantLabel">
         <constraints>
-          <grid row="12" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="438" height="0"/>
           </grid>
-          <forms/>
         </constraints>
         <properties>
           <enabled value="true"/>
           <text value=""/>
         </properties>
       </component>
-      <component id="9e202" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="20" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="438" height="16"/>
-          </grid>
-          <forms/>
-        </constraints>
-        <properties>
-          <text value="batch command  &quot;;&quot; splitting, asy task addition &gt;&gt; test.out &amp; "/>
-        </properties>
-      </component>
       <component id="eedb" class="javax.swing.JRadioButton" binding="selectCommandCloseDialogRadioButton">
         <constraints>
-          <grid row="18" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="438" height="22"/>
           </grid>
-          <forms/>
         </constraints>
         <properties>
           <text value="close this window after seleced one command"/>
         </properties>
       </component>
+      <component id="bde56" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="dymastic commands"/>
+        </properties>
+      </component>
+      <grid id="9e539" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="22c1c" class="com.intellij.ui.components.labels.ActionLink" binding="dyScHelpLink" custom-create="true">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="sc -d get classloader"/>
+            </properties>
+          </component>
+          <component id="b3bc1" class="javax.swing.JTextField" binding="dyClassloaderHashTextField">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+        </children>
+      </grid>
+      <grid id="7fc12" layout-manager="FormLayout">
+        <rowspec value="center:d:grow"/>
+        <colspec value="fill:846px:grow"/>
+        <colspec value="fill:118px:noGrow"/>
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="fdea2" class="javax.swing.JComboBox" binding="shellScriptComboBox">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="100" height="23"/>
+              </grid>
+              <forms defaultalign-horz="false" defaultalign-vert="false"/>
+            </constraints>
+            <properties>
+              <editable value="true"/>
+            </properties>
+          </component>
+          <component id="da19e" class="javax.swing.JButton" binding="shellScriptCommandButton" default-binding="true">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="68" height="23"/>
+              </grid>
+              <forms defaultalign-horz="false" defaultalign-vert="false"/>
+            </constraints>
+            <properties>
+              <text value="shell command"/>
+              <toolTipText value="直接执行脚本无需打开arthas"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <grid id="3721" layout-manager="FormLayout">
+        <rowspec value="center:d:grow"/>
+        <colspec value="fill:846px:grow"/>
+        <colspec value="fill:118px:noGrow"/>
+        <constraints>
+          <grid row="8" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="3ca4d" class="javax.swing.JComboBox" binding="commonShellScriptComboBox" default-binding="true">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="438" height="27"/>
+              </grid>
+              <forms/>
+            </constraints>
+            <properties>
+              <editable value="true"/>
+            </properties>
+          </component>
+          <component id="50006" class="javax.swing.JButton" binding="commonShellScriptCommandButton" default-binding="true">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <forms defaultalign-horz="false" defaultalign-vert="false"/>
+            </constraints>
+            <properties>
+              <text value="shell command"/>
+              <toolTipText value="直接执行脚本无需打开arthas"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <component id="5e63d" class="javax.swing.JButton" binding="dyCopyCommandButton">
+        <constraints>
+          <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="7" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="copy  command"/>
+          <toolTipText value="命令复制到剪切板 到服务器启动arhtas 执行命令 部分脚本可能不支持哦,需要classloader hashcode"/>
+        </properties>
+      </component>
+      <component id="612c7" class="javax.swing.JButton" binding="dyCopyScCommandButton" default-binding="true">
+        <constraints>
+          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="copy sc command"/>
+        </properties>
+      </component>
+      <component id="70f7d" class="javax.swing.JButton" binding="closeScriptButton">
+        <constraints>
+          <grid row="10" column="1" row-span="1" col-span="2" vsize-policy="7" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="close  command"/>
+        </properties>
+      </component>
       <component id="4de36" class="javax.swing.JButton" binding="commonCopyCommandButton">
         <constraints>
-          <grid row="16" column="3" row-span="1" col-span="1" vsize-policy="7" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
-          <forms defaultalign-horz="false" defaultalign-vert="false"/>
+          <grid row="9" column="1" row-span="1" col-span="2" vsize-policy="7" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="copy command"/>
           <toolTipText value="命令复制到剪切板 到服务器启动arhtas 执行命令 部分为批量脚本 不能执行哦"/>
         </properties>
       </component>
-      <component id="50006" class="javax.swing.JButton" binding="commonShellScriptCommandButton" default-binding="true">
-        <constraints>
-          <grid row="14" column="3" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
-          <forms defaultalign-horz="false" defaultalign-vert="false"/>
-        </constraints>
-        <properties>
-          <text value="shell command"/>
-          <toolTipText value="直接执行脚本无需打开arthas"/>
-        </properties>
-      </component>
-      <component id="5e63d" class="javax.swing.JButton" binding="dyCopyCommandButton">
-        <constraints>
-          <grid row="8" column="3" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
-          <forms defaultalign-horz="false" defaultalign-vert="false"/>
-        </constraints>
-        <properties>
-          <text value="copy command"/>
-          <toolTipText value="命令复制到剪切板 到服务器启动arhtas 执行命令 部分脚本可能不支持哦,需要classloader hashcode"/>
-        </properties>
-      </component>
-      <component id="da19e" class="javax.swing.JButton" binding="shellScriptCommandButton" default-binding="true">
-        <constraints>
-          <grid row="6" column="3" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="68" height="23"/>
-          </grid>
-          <forms defaultalign-horz="false" defaultalign-vert="false"/>
-        </constraints>
-        <properties>
-          <text value="shell command"/>
-          <toolTipText value="直接执行脚本无需打开arthas"/>
-        </properties>
-      </component>
-      <component id="70f7d" class="javax.swing.JButton" binding="closeScriptButton">
-        <constraints>
-          <grid row="18" column="3" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
-          <forms defaultalign-horz="false" defaultalign-vert="false"/>
-        </constraints>
-        <properties>
-          <text value="close"/>
-        </properties>
-      </component>
-      <component id="bde56" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-          <forms/>
-        </constraints>
-        <properties>
-          <text value="dymastic commands"/>
-        </properties>
-      </component>
       <component id="2f83e" class="javax.swing.JLabel">
         <constraints>
-          <grid row="10" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-          <forms/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="static commands"/>
+        </properties>
+      </component>
+      <component id="12680" class="javax.swing.JSeparator">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="2b8dc" class="javax.swing.JButton" binding="dyClearCacheButton" default-binding="true">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="clear cache"/>
+          <toolTipText value="clear  cache of previously used classloaders "/>
         </properties>
       </component>
     </children>

--- a/src/com/github/wangji92/arthas/plugin/ui/ArthasShellScriptCommandDialog.java
+++ b/src/com/github/wangji92/arthas/plugin/ui/ArthasShellScriptCommandDialog.java
@@ -162,10 +162,9 @@ public class ArthasShellScriptCommandDialog extends JDialog {
                     dyTipLabel.setText(item.getTipText());
                     this.currentSelectDyScriptVariableEnum = item;
                 }
-
             }
         });
-        shellScriptComboBox.setRenderer(new CustomDefaultListCellRenderer(shellScriptComboBox));
+        shellScriptComboBox.setRenderer(new CustomDefaultListCellRenderer(shellScriptComboBox, dyTipLabel));
 
         for (ShellScriptCommandEnum shellScript : ShellScriptCommandEnum.values()) {
             if (!shellScript.support(this.commandContext)) {
@@ -216,7 +215,7 @@ public class ArthasShellScriptCommandDialog extends JDialog {
                 }
             }
         });
-        commonShellScriptComboBox.setRenderer(new CustomDefaultListCellRenderer(commonShellScriptComboBox));
+        commonShellScriptComboBox.setRenderer(new CustomDefaultListCellRenderer(commonShellScriptComboBox, this.constantLabel));
         commonShellScriptCommandButton.addActionListener(e -> {
             Object selectedItem = commonShellScriptComboBox.getSelectedItem();
             assert selectedItem != null;


### PR DESCRIPTION
## 快捷命令增加 可以手动输入 sc -d  获取classloader的逻辑
*  手动输入 sc -d  获取classloader的逻辑 
快捷命令这里增加了一些其他的命令没有的功能，比如 反射修改非静态字段的值。
*  优化了界面tip 提示，选择框的移动进行动态展示tip，界面调整了一下。

![image](https://user-images.githubusercontent.com/20874972/127741855-b9dba739-4987-4788-9313-e64829185980.png)
