### PR TITLE
增加中文自动转换控制的控制的开关,发布版本

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.github.wangji92.arthas.plugin</id>
     <name>arthas idea</name>
-    <version>2.34</version>
+    <version>2.35</version>
     <vendor email="983433479@qq.com" url="https://github.com/WangJi92/arthas-idea-plugin">汪小哥</vendor>
 
     <description><![CDATA[
@@ -42,6 +42,13 @@
     ]]></description>
 
     <change-notes><![CDATA[
+    <p>2.35-RELEASE</p>
+      <ul>
+        <li>support input chinese auto convert to unicode <a href="https://github.com/alibaba/arthas/blob/master/site/src/site/sphinx/faq.md#%E8%BE%93%E5%85%A5%E4%B8%AD%E6%96%87unicode%E5%AD%97%E7%AC%A6">link</a></li>
+      </ul>
+       <ul>
+        <li>支持输入的中文字符串自动转化为unicode编码<a href="https://github.com/alibaba/arthas/blob/master/site/src/site/sphinx/faq.md#%E8%BE%93%E5%85%A5%E4%B8%AD%E6%96%87unicode%E5%AD%97%E7%AC%A6">官方的使用链接</a></li>
+      </ul>
      <p>2.34-RELEASE</p>
       <ul>
         <li>fix some bug in 2021.3</li>

--- a/src/com/github/wangji92/arthas/plugin/setting/AppSettingsState.java
+++ b/src/com/github/wangji92/arthas/plugin/setting/AppSettingsState.java
@@ -182,8 +182,24 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
      */
     public String scriptDialogCloseWhenSelectedCommand = "y";
 
+    /**
+     * 自动转换为 Unicode 编码将中文信息
+     */
+    public boolean autoToUnicode = true;
+
+    /**
+     * 获取工程的名称
+     * @return
+     */
+    public static Project getProject(){
+        return projectInfo;
+    }
+
+    private static  Project projectInfo;
+
 
     public static AppSettingsState getInstance(@NotNull Project project) {
+        projectInfo = project;
         AppSettingsState appSettingsState = ServiceManager.getService(project, AppSettingsState.class);
         // 检测全局的static spring context
         checkGlobalStaticSpringContextAndSettingCurrentProjectIfEmpty(appSettingsState);
@@ -206,6 +222,9 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
          * 检查快捷脚本是否关闭窗口
          */
         checkGlobalScriptDialogCloseWhenSelectedCommand(appSettingsState);
+
+        checkGlobalAutoToUnicode(appSettingsState);
+
         return appSettingsState;
     }
 
@@ -243,6 +262,18 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
                 appSettingsState.hotRedefineRedis = false;
                 appSettingsState.aliYunOss = false;
             }
+        }
+    }
+
+    /**
+     * 使用全局的配置  自动转换为 Unicode 编码将中文信息
+     *
+     * @param appSettingsState
+     */
+    private static void checkGlobalAutoToUnicode(AppSettingsState appSettingsState) {
+        String autoToUnicode = PropertiesComponentUtils.getValue("autoToUnicode");
+        if (StringUtils.isNotBlank(autoToUnicode)) {
+            appSettingsState.autoToUnicode = "y".equals(autoToUnicode);
         }
     }
 

--- a/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.form
+++ b/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="1474" height="714"/>
+      <xy x="20" y="20" width="1479" height="806"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -19,7 +19,7 @@
         </properties>
         <border type="etched"/>
         <children>
-          <grid id="a5445" binding="basicSettingPane" layout-manager="GridLayoutManager" row-count="11" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="a5445" binding="basicSettingPane" layout-manager="GridLayoutManager" row-count="12" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="10" left="10" bottom="10" right="10"/>
             <constraints>
               <tabbedpane title="Basic Setting"/>
@@ -39,7 +39,7 @@
               </component>
               <vspacer id="c6b4f">
                 <constraints>
-                  <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                  <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
               <component id="2e7dc" class="com.intellij.ui.components.labels.LinkLabel" binding="springContextProviderLink" custom-create="true">
@@ -216,6 +216,31 @@
                 </constraints>
                 <properties>
                   <text value="arthas idea plugin yuqu document"/>
+                </properties>
+              </component>
+              <component id="13d23" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Auto Convert Chinese To Unicode"/>
+                  <toolTipText value="输入参数为中文自动转换为unicode 编码"/>
+                </properties>
+              </component>
+              <component id="5a3a" class="com.intellij.ui.components.labels.LinkLabel" binding="howToInputChinseParamLink" custom-create="true">
+                <constraints>
+                  <grid row="10" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="How To Input Chinese Param Link"/>
+                </properties>
+              </component>
+              <component id="5ee4e" class="javax.swing.JRadioButton" binding="autoToUnicodeRadioButton" default-binding="true">
+                <constraints>
+                  <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Auto To Unicode"/>
                 </properties>
               </component>
             </children>

--- a/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.java
+++ b/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.java
@@ -215,6 +215,14 @@ public class AppSettingsPage implements Configurable {
      * 语雀知识库链接
      */
     private LinkLabel arthasYuQueDocumentLink;
+    /**
+     * 自动转换为中文编码
+     */
+    private JRadioButton autoToUnicodeRadioButton;
+    /**
+     * 自动将中文转换为 unicode 编码
+     */
+    private LinkLabel howToInputChinseParamLink;
 
 
     @Nls(capitalization = Nls.Capitalization.Title)
@@ -258,6 +266,7 @@ public class AppSettingsPage implements Configurable {
         this.arthasIdeaGithubLink = ActionLinkUtils.newActionLink("https://github.com/WangJi92/arthas-idea-plugin");
         this.arthasIdeaDemoLink = ActionLinkUtils.newActionLink("https://github.com/WangJi92/arthas-plugin-demo");
         this.arthasYuQueDocumentLink = ActionLinkUtils.newActionLink("https://www.yuque.com/arthas-idea-plugin");
+        this.howToInputChinseParamLink = ActionLinkUtils.newActionLink("https://github.com/alibaba/arthas/blob/master/site/src/site/sphinx/faq.md#%E8%BE%93%E5%85%A5%E4%B8%AD%E6%96%87unicode%E5%AD%97%E7%AC%A6");
 
     }
 
@@ -287,7 +296,8 @@ public class AppSettingsPage implements Configurable {
                 || manualSelectPidRadioButton.isSelected() != settings.manualSelectPid
                 || !arthasPackageZipDownloadUrlTextField.getText().equalsIgnoreCase(settings.arthasPackageZipDownloadUrl)
                 || !mybatisMapperReloadMethodNameTextField.getText().equalsIgnoreCase(settings.mybatisMapperReloadMethodName)
-                || !mybatisMapperReloadServiceBeanNameTextField.getText().equalsIgnoreCase(settings.mybatisMapperReloadServiceBeanName);
+                || !mybatisMapperReloadServiceBeanNameTextField.getText().equalsIgnoreCase(settings.mybatisMapperReloadServiceBeanName)
+                || autoToUnicodeRadioButton.isSelected() != settings.autoToUnicode;
 
         if (modify) {
             return modify;
@@ -355,6 +365,8 @@ public class AppSettingsPage implements Configurable {
         settings.redefineBeforeCompile = redefineBeforeCompileRadioButton.isSelected();
         settings.printConditionExpress = printConditionExpressRadioButton.isSelected();
         settings.arthasPackageZipDownloadUrl = arthasPackageZipDownloadUrlTextField.getText();
+        settings.autoToUnicode = autoToUnicodeRadioButton.isSelected();
+        PropertiesComponentUtils.setValue("autoToUnicode", autoToUnicodeRadioButton.isSelected() ? "y" : "n");
         // 设置到全局
         PropertiesComponentUtils.setValue("arthasPackageZipDownloadUrl", arthasPackageZipDownloadUrlTextField.getText());
         if (clipboardRadioButton.isSelected()) {
@@ -498,6 +510,7 @@ public class AppSettingsPage implements Configurable {
         hotRedefineDeleteFileRadioButton.setSelected(settings.hotRedefineDelete);
         redefineBeforeCompileRadioButton.setSelected(settings.redefineBeforeCompile);
         printConditionExpressRadioButton.setSelected(settings.printConditionExpress);
+        autoToUnicodeRadioButton.setSelected(settings.autoToUnicode);
         selectProjectNameTextField.setText(settings.selectProjectName);
 
         ossEndpointTextField.setText(settings.endpoint);

--- a/src/com/github/wangji92/arthas/plugin/utils/ClipboardUtils.java
+++ b/src/com/github/wangji92/arthas/plugin/utils/ClipboardUtils.java
@@ -1,5 +1,8 @@
 package com.github.wangji92.arthas.plugin.utils;
 
+import com.github.wangji92.arthas.plugin.setting.AppSettingsState;
+import com.intellij.openapi.project.Project;
+
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
@@ -49,9 +52,17 @@ public class ClipboardUtils {
         try {
             // 获取系统剪贴板
             Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-            // 将中文转换为 unicode  这里写法
+            // 将中文转换为 unicode  这里写法 通过断点跟踪其实这个 转换的逻辑是ognl 解析表达式的时候搞定的
             // https://github.com/alibaba/arthas/blob/master/site/src/site/sphinx/faq.md#%E8%BE%93%E5%85%A5%E4%B8%AD%E6%96%87unicode%E5%AD%97%E7%AC%A6
             String command = ChineseUnicodeConvert.chineseToUnicode(text);
+            // 增加开关控制...
+            Project projectName = AppSettingsState.getProject();
+            if (projectName != null) {
+                AppSettingsState instance = AppSettingsState.getInstance(projectName);
+                if (!instance.autoToUnicode) {
+                    command = text;
+                }
+            }
             // 封装文本内容
             Transferable trans = new StringSelection(command);
             // 把文本内容设置到系统剪贴板


### PR DESCRIPTION
arthas 支持unicode 自动转换为中文的操作不是arthas  流程中处理的 ，是ognl 解析表达式的时候会自动转换为中文 

ognl.Ognl#parseExpression
```bash
 vmtool -x 3 --action getInstances --className com.wangji92.arthas.plugin.demo.controller.CommonController  --express 'instances[0].traceE("\u4E2D\u6587")'  -c 60addb54
```
![image](https://user-images.githubusercontent.com/20874972/156400188-3cce7790-4323-42f0-a41e-692be720cd15.png)
