### PR TITLE
动态脚本支持aws s3 存储脚本内容 & 静态脚本里面增加常用快捷脚本

### DIFF
--- a/.idea/libraries/com_amazonaws_aws_java_sdk_s3_1_12_321.xml
+++ b/.idea/libraries/com_amazonaws_aws_java_sdk_s3_1_12_321.xml
@@ -1,0 +1,26 @@
+<component name="libraryTable">
+  <library name="com.amazonaws:aws-java-sdk-s3:1.12.321" type="repository">
+    <properties maven-id="com.amazonaws:aws-java-sdk-s3:1.12.321" />
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/aws-java-sdk-s3/1.12.321/aws-java-sdk-s3-1.12.321.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/aws-java-sdk-kms/1.12.321/aws-java-sdk-kms-1.12.321.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/aws-java-sdk-core/1.12.321/aws-java-sdk-core-1.12.321.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/commons-logging/commons-logging/1.1.3/commons-logging-1.1.3.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/commons-codec/commons-codec/1.15/commons-codec-1.15.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.12.6.1/jackson-databind-2.12.6.1.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.12.6/jackson-annotations-2.12.6.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.12.6/jackson-core-2.12.6.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.12.6/jackson-dataformat-cbor-2.12.6.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/joda-time/joda-time/2.8.1/joda-time-2.8.1.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/jmespath-java/1.12.321/jmespath-java-1.12.321.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.ideaLibSources/aws-java-sdk-s3-1.12.321-sources.jar!/" />
+      <root url="jar://$USER_HOME$/.ideaLibSources/aws-java-sdk-core-1.12.321-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/arthas-idea-plugin.iml
+++ b/arthas-idea-plugin.iml
@@ -16,5 +16,6 @@
     <orderEntry type="library" name="com.google.guava:guava:23.0" level="project" />
     <orderEntry type="library" name="commons-collections:commons-collections:3.2.2" level="project" />
     <orderEntry type="library" name="redis.clients:jedis:3.4.1" level="project" />
+    <orderEntry type="library" name="com.amazonaws:aws-java-sdk-s3:1.12.321" level="project" />
   </component>
 </module>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.github.wangji92.arthas.plugin</id>
     <name>arthas idea</name>
-    <version>2.38</version>
+    <version>2.39</version>
     <vendor email="983433479@qq.com" url="https://github.com/WangJi92/arthas-idea-plugin">汪小哥</vendor>
 
     <description><![CDATA[
@@ -42,6 +42,15 @@
     ]]></description>
 
     <change-notes><![CDATA[
+     <p>2.39-RELEASE</p>
+      <ul>
+        <li><a href="https://github.com/WangJi92/arthas-idea-plugin/issues/80">静态脚本里面增加常用快捷脚本，eg 观察spring http请求耗时、观察jdbc 执行的sql </a></li>
+        <li>动态脚本比如热更新、快捷shell 脚本、上传本地文件等功能都需要对象存储存储脚本内容,之前只支持 redis 、剪切板、 阿里云oss <a href="https://github.com/WangJi92/arthas-idea-plugin/issues/79">aws s3 很多厂商都支持 比如minio、华为云、腾讯云等等</a></li>
+      </ul>
+       <ul>
+        <li><a href="https://github.com/WangJi92/arthas-idea-plugin/issues/80"> Common shortcut scripts are added to static scripts. eg observes the time consuming of spring http requests and the sql executed by jdbc</a></li>
+        <li>Dynamic scripts, such as hot updates, quick shell scripts, and uploading local files, require objects storage to store script content. Previously, only Redis, clipboard, and Alibaba Cloud OSS were supported <a href="https://github.com/WangJi92/arthas-idea-plugin/issues/79 ">Many manufacturers of aws s3 support minio, Huawei Cloud, Tencent Cloud, etc</a></li>
+      </ul>
      <p>2.38-RELEASE</p>
       <ul>
         <li>Optimize whether the high-frequency command vmtool is displayed</li>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -537,7 +537,7 @@
 
         <action id="LocalFileUploadToOssAction"
                 class="com.github.wangji92.arthas.plugin.action.arthas.LocalFileUploadToOssAction"
-                text="Local File Upload To Oss"
+                text="Local File Upload To Object Storage"
                 description="LocalFileUploadToOssAction">
         </action>
 

--- a/src/com/github/wangji92/arthas/plugin/action/arthas/ArthasAsyncProfilerCommandAction.java
+++ b/src/com/github/wangji92/arthas/plugin/action/arthas/ArthasAsyncProfilerCommandAction.java
@@ -1,7 +1,6 @@
 package com.github.wangji92.arthas.plugin.action.arthas;
 
 import com.github.wangji92.arthas.plugin.ui.ArthasAsyncProfileDialog;
-import com.github.wangji92.arthas.plugin.ui.ArthasSpecialDialog;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;

--- a/src/com/github/wangji92/arthas/plugin/common/enums/ShellScriptConstantEnum.java
+++ b/src/com/github/wangji92/arthas/plugin/common/enums/ShellScriptConstantEnum.java
@@ -10,8 +10,12 @@ import com.github.wangji92.arthas.plugin.common.enums.base.EnumCodeMsg;
  */
 public enum ShellScriptConstantEnum implements EnumCodeMsg<String> {
     /**
-     * force gc
+     * https://www.yuque.com/arthas-idea-plugin/help/zkuar3
      */
+    WATCH_SPRING_HTTP("watch org.springframework.web.servlet.DispatcherServlet doService '{params[0].getRequestURI()+\" \"+ #cost}'  -n 5  -x 3 '#cost>1'","watch spring http request cost"),
+    WATCH_SPRING_HTTP_HEADER(" watch org.springframework.web.servlet.DispatcherServlet doService '{params[0].getRequestURI()+\"  header=\"+params[1].getHeaders(\"trace-id\")}'  -n 10  -x 3 -f","watch spring http response header"),
+    WATCH_MYBATIS_BOUND_SQL("watch org.apache.ibatis.mapping.BoundSql getSql '{returnObj,target.parameterObject,throwExp}'  -n 5  -x 3","watch mybatis boundSql"),
+    WATCH_JDBC_REQUEST("watch java.sql.Connection prepareStatement '{params,throwExp}'  -n 5  -x 3  'clazz.getName().startsWith(\"com.mysql\") and params.length==1' and #cost>1 ","watch jdbc sql"),
     VM_TOOL_FORCE_GC("vmtool --action forceGc", "force gc"),
     BATCH_THREAD("thread -i 3000 -n 5;thread -b;thread --state BLOCKED;", "batch thread"),
     PROFILER("profiler start --event cpu --interval 10000000 --format jfr -duration 180", "采集cpu jfr，支持jfr格式的工具来查看,JDK Mission Control or JProfiler 执行 180秒自动结束"),

--- a/src/com/github/wangji92/arthas/plugin/setting/AppSettingsState.java
+++ b/src/com/github/wangji92/arthas/plugin/setting/AppSettingsState.java
@@ -99,6 +99,39 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
     public boolean aliYunOss = false;
 
     /**
+     * aws
+     */
+    public boolean awsS3 = false;
+
+
+    public String s3Endpoint;
+
+    public String s3Region;
+
+    /**
+     * accessKeyId
+     */
+    public String s3AccessKeyId;
+
+    /**
+     * accessKeySecret
+     */
+    public String s3AccessKeySecret;
+
+    /**
+     * bucketName
+     */
+    public String s3BucketName;
+
+    /**
+     * 存储的路径
+     */
+    public String s3DirectoryPrefix = "arthas/";
+
+
+    public boolean s3GlobalConfig = true;
+
+    /**
      * spring context 全局默认配置
      */
     public boolean springContextGlobalSetting = true;
@@ -189,13 +222,14 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
 
     /**
      * 获取工程的名称
+     *
      * @return
      */
-    public static Project getProject(){
+    public static Project getProject() {
         return projectInfo;
     }
 
-    private static  Project projectInfo;
+    private static Project projectInfo;
 
 
     public static AppSettingsState getInstance(@NotNull Project project) {
@@ -208,6 +242,9 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
 
         // 检测 全局的阿里云oss
         checkGlobalAliyunOssAndSettingCurrentProjectIfEmpty(appSettingsState);
+
+        //aws
+        checkGlobalS3AndSettingCurrentProjectIfEmpty(appSettingsState);
 
         // 检测全局的redis 配置
         checkGlobalRedisAndSettingCurrentProjectIfEmpty(appSettingsState);
@@ -229,6 +266,31 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
     }
 
     /**
+     * 设置信息
+     *
+     * @param appSettingsState
+     */
+    private static void checkGlobalS3AndSettingCurrentProjectIfEmpty(AppSettingsState appSettingsState) {
+        String endPoint1 = PropertiesComponentUtils.getValue("s3Endpoint");
+        String bucketName1 = PropertiesComponentUtils.getValue("s3BucketName");
+        String accessKeyId1 = PropertiesComponentUtils.getValue("s3AccessKeyId");
+        String accessKeySecret1 = PropertiesComponentUtils.getValue("s3AccessKeySecret");
+        String directoryPrefix1 = PropertiesComponentUtils.getValue("s3DirectoryPrefix");
+        String region = PropertiesComponentUtils.getValue("s3Region");
+        if (StringUtils.isNotBlank(bucketName1)
+                && StringUtils.isNotBlank(endPoint1)
+                && StringUtils.isNotBlank(accessKeyId1)
+                && StringUtils.isNotBlank(accessKeySecret1)) {
+            appSettingsState.s3Endpoint = endPoint1;
+            appSettingsState.s3AccessKeyId = accessKeyId1;
+            appSettingsState.s3BucketName = bucketName1;
+            appSettingsState.s3AccessKeySecret = accessKeySecret1;
+            appSettingsState.s3DirectoryPrefix = directoryPrefix1;
+            appSettingsState.s3Region = region;
+        }
+    }
+
+    /**
      * 全局检测设置信息 只要一个工程修改了 全部都修改
      *
      * @param appSettingsState
@@ -243,24 +305,35 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
                 appSettingsState.hotRedefineClipboard = true;
                 appSettingsState.hotRedefineRedis = false;
                 appSettingsState.aliYunOss = false;
+                appSettingsState.awsS3 = false;
                 break;
             }
             case "hotRedefineRedis": {
                 appSettingsState.hotRedefineClipboard = false;
                 appSettingsState.hotRedefineRedis = true;
                 appSettingsState.aliYunOss = false;
+                appSettingsState.awsS3 = false;
                 break;
             }
             case "aliYunOss": {
                 appSettingsState.hotRedefineClipboard = false;
                 appSettingsState.hotRedefineRedis = false;
                 appSettingsState.aliYunOss = true;
+                appSettingsState.awsS3 = false;
+                break;
+            }
+            case "awsS3": {
+                appSettingsState.hotRedefineClipboard = false;
+                appSettingsState.hotRedefineRedis = false;
+                appSettingsState.aliYunOss = false;
+                appSettingsState.awsS3 = true;
                 break;
             }
             default: {
                 appSettingsState.hotRedefineClipboard = true;
                 appSettingsState.hotRedefineRedis = false;
                 appSettingsState.aliYunOss = false;
+                appSettingsState.awsS3 = false;
             }
         }
     }
@@ -341,7 +414,8 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
             if (NumberUtils.isDigits(redisCacheKeyTtl)) {
                 appSettingsState.redisCacheKeyTtl = Integer.parseInt(redisCacheKeyTtl);
             }
-            if (!appSettingsState.aliYunOss && !appSettingsState.hotRedefineClipboard) {
+            if (!appSettingsState.aliYunOss && !appSettingsState.hotRedefineClipboard
+                    && !appSettingsState.awsS3) {
                 appSettingsState.hotRedefineRedis = true;
             }
         }
@@ -383,7 +457,9 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
                 && StringUtils.isNotBlank(endPoint1)
                 && StringUtils.isNotBlank(accessKeyId1)
                 && StringUtils.isNotBlank(accessKeySecret1)) {
-            if (!appSettingsState.hotRedefineRedis && !appSettingsState.hotRedefineClipboard) {
+            if (!appSettingsState.hotRedefineRedis
+                    && !appSettingsState.hotRedefineClipboard
+                    && !appSettingsState.awsS3) {
                 appSettingsState.aliYunOss = true;
             }
             appSettingsState.endpoint = endPoint1;

--- a/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.form
+++ b/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="1479" height="806"/>
+      <xy x="20" y="20" width="1531" height="931"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -227,7 +227,7 @@
                   <toolTipText value="输入参数为中文自动转换为unicode 编码"/>
                 </properties>
               </component>
-              <component id="5a3a" class="com.intellij.ui.components.labels.LinkLabel" binding="howToInputChinseParamLink" custom-create="true">
+              <component id="5a3a" class="com.intellij.ui.components.labels.LinkLabel" binding="howToInputChineseParamLink" custom-create="true">
                 <constraints>
                   <grid row="10" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -245,7 +245,7 @@
               </component>
             </children>
           </grid>
-          <grid id="f4b0a" binding="hotRedefineSettingPane" layout-manager="GridLayoutManager" row-count="7" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="f4b0a" binding="hotRedefineSettingPane" layout-manager="GridLayoutManager" row-count="8" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="10" left="10" bottom="10" right="10"/>
             <constraints>
               <tabbedpane title="Storage And Script Setting"/>
@@ -266,7 +266,7 @@
               </component>
               <vspacer id="d59d5">
                 <constraints>
-                  <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                  <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
               <component id="bf4f" class="javax.swing.JRadioButton" binding="clipboardRadioButton">
@@ -402,7 +402,7 @@
                       <grid row="6" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
-                      <text value="Oss configuration detection"/>
+                      <text value="Oss config detection"/>
                     </properties>
                   </component>
                   <component id="2c4c8" class="com.intellij.ui.components.labels.LinkLabel" binding="ossHelpLink" custom-create="true">
@@ -456,7 +456,7 @@
                 <colspec value="left:4dlu:noGrow"/>
                 <colspec value="fill:max(d;4px):noGrow"/>
                 <constraints>
-                  <grid row="4" column="0" row-span="1" col-span="7" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="0" row-span="1" col-span="7" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>
@@ -493,7 +493,7 @@
               </grid>
               <component id="1c575" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Script select process configuration"/>
@@ -501,7 +501,7 @@
               </component>
               <component id="64342" class="javax.swing.JRadioButton" binding="manualSelectPidRadioButton">
                 <constraints>
-                  <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Manual selection process"/>
@@ -509,7 +509,7 @@
               </component>
               <component id="cea1e" class="javax.swing.JRadioButton" binding="preConfigurationSelectPidRadioButton">
                 <constraints>
-                  <grid row="3" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="4" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Pre-configured project name  --select  project name (jps -l)"/>
@@ -527,7 +527,7 @@
               <grid id="196b3" binding="redisSettingPane" layout-manager="GridLayoutManager" row-count="5" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="5" left="5" bottom="5" right="5"/>
                 <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="7" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                  <grid row="3" column="0" row-span="1" col-span="7" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="0" height="50"/>
                   </grid>
                 </constraints>
@@ -586,7 +586,7 @@
                       <grid row="3" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
-                      <text value="redis configuration detection"/>
+                      <text value="redis config detection"/>
                     </properties>
                   </component>
                   <component id="42edc" class="javax.swing.JTextField" binding="redisAddressTextField">
@@ -654,7 +654,7 @@
               </grid>
               <component id="e9096" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Arthas Package Zip Download Url"/>
@@ -663,7 +663,7 @@
               </component>
               <component id="9325e" class="javax.swing.JTextField" binding="arthasPackageZipDownloadUrlTextField">
                 <constraints>
-                  <grid row="5" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="6" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -673,12 +673,184 @@
               </component>
               <component id="89eb7" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="5" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="6" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Server cannot access arthas download address can be specified manually"/>
                 </properties>
               </component>
+              <component id="f261a" class="javax.swing.JRadioButton" binding="s3RadioButton">
+                <constraints>
+                  <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value=" Object Storage S3"/>
+                  <toolTipText value="aws s3 对象存储"/>
+                </properties>
+              </component>
+              <grid id="622a6" binding="s3Panel" layout-manager="GridLayoutManager" row-count="9" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="5" left="5" bottom="5" right="5"/>
+                <constraints>
+                  <grid row="2" column="0" row-span="1" col-span="7" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                    <preferred-size width="0" height="51"/>
+                  </grid>
+                </constraints>
+                <properties/>
+                <border type="etched" title=""/>
+                <children>
+                  <component id="7d31b" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="S3 Endpoint"/>
+                      <toolTipText value="eg: http://oss-cn-hangzhou.aliyuncs.com"/>
+                    </properties>
+                  </component>
+                  <vspacer id="1e382">
+                    <constraints>
+                      <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                  </vspacer>
+                  <component id="b8c42" class="javax.swing.JTextField" binding="s3EndPointField">
+                    <constraints>
+                      <grid row="0" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties/>
+                  </component>
+                  <component id="c930a" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="S3 AccessKeyId"/>
+                      <toolTipText value="yourAccessKeyId"/>
+                    </properties>
+                  </component>
+                  <component id="e1200" class="javax.swing.JPasswordField" binding="s3AkField">
+                    <constraints>
+                      <grid row="1" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties/>
+                  </component>
+                  <component id="5a1cb" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="S3 AccessKeySecret"/>
+                      <toolTipText value="yourAccessKeySecret"/>
+                    </properties>
+                  </component>
+                  <component id="c771d" class="javax.swing.JPasswordField" binding="s3SkField">
+                    <constraints>
+                      <grid row="2" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties/>
+                  </component>
+                  <component id="e7c89" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="S3 BucketName"/>
+                      <toolTipText value="yourBucketName"/>
+                    </properties>
+                  </component>
+                  <component id="f6211" class="javax.swing.JTextField" binding="s3BucketNameField">
+                    <constraints>
+                      <grid row="3" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties/>
+                  </component>
+                  <component id="3ed54" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="S3 Directory Prefix"/>
+                      <toolTipText value="oss 存储文件空间的地址前缀可以为空( abc/efg/ 为前缀  abc/efg/123.jpg)"/>
+                    </properties>
+                  </component>
+                  <component id="a594e" class="javax.swing.JTextField" binding="s3DirPrefixField">
+                    <constraints>
+                      <grid row="5" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties/>
+                  </component>
+                  <hspacer id="dcc03">
+                    <constraints>
+                      <grid row="7" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                  </hspacer>
+                  <component id="f3dbf" class="javax.swing.JButton" binding="s3CheckButton">
+                    <constraints>
+                      <grid row="7" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="S3 config detection"/>
+                    </properties>
+                  </component>
+                  <component id="e777b" class="javax.swing.JLabel" binding="s3CheckMessageLabel">
+                    <constraints>
+                      <grid row="7" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="33cf" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="S3 Setting Scope"/>
+                      <toolTipText value="Oss 设置作用范围"/>
+                    </properties>
+                  </component>
+                  <hspacer id="e00a3">
+                    <constraints>
+                      <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                  </hspacer>
+                  <component id="d9544" class="javax.swing.JRadioButton" binding="s3GlobalConfigField">
+                    <constraints>
+                      <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="S3 global configuration"/>
+                      <toolTipText value="是否当前配置作为全局默认配置"/>
+                    </properties>
+                  </component>
+                  <component id="37c89" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="S3 Region"/>
+                      <toolTipText value="yourBucketName"/>
+                    </properties>
+                  </component>
+                  <component id="bb16f" class="javax.swing.JTextField" binding="s3RegionField">
+                    <constraints>
+                      <grid row="4" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties/>
+                  </component>
+                </children>
+              </grid>
             </children>
           </grid>
           <grid id="22a0e" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.form
+++ b/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="1531" height="931"/>
+      <xy x="20" y="20" width="1470" height="931"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -245,7 +245,7 @@
               </component>
             </children>
           </grid>
-          <grid id="f4b0a" binding="hotRedefineSettingPane" layout-manager="GridLayoutManager" row-count="8" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="f4b0a" binding="hotRedefineSettingPane" layout-manager="GridLayoutManager" row-count="8" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="10" left="10" bottom="10" right="10"/>
             <constraints>
               <tabbedpane title="Storage And Script Setting"/>
@@ -280,7 +280,7 @@
               </component>
               <hspacer id="5ec22">
                 <constraints>
-                  <grid row="0" column="5" row-span="1" col-span="2" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="0" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
               </hspacer>
               <component id="ebf7f" class="javax.swing.JRadioButton" binding="aliYunOssRadioButton">
@@ -295,7 +295,7 @@
               <grid id="4aed9" binding="aliyunOssSettingPane" layout-manager="GridLayoutManager" row-count="8" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="5" left="5" bottom="5" right="5"/>
                 <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="7" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                  <grid row="1" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="0" height="51"/>
                   </grid>
                 </constraints>
@@ -333,7 +333,7 @@
                       <toolTipText value="yourAccessKeyId"/>
                     </properties>
                   </component>
-                  <component id="50202" class="javax.swing.JPasswordField" binding="ossAccessKeyIdPasswordField">
+                  <component id="668ce" class="javax.swing.JTextField" binding="ossAccessKeyIdPasswordField">
                     <constraints>
                       <grid row="1" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
@@ -350,7 +350,7 @@
                       <toolTipText value="yourAccessKeySecret"/>
                     </properties>
                   </component>
-                  <component id="330b8" class="javax.swing.JPasswordField" binding="ossAccessKeySecretPasswordField">
+                  <component id="85a5f" class="javax.swing.JTextField" binding="ossAccessKeySecretPasswordField">
                     <constraints>
                       <grid row="2" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
@@ -456,7 +456,7 @@
                 <colspec value="left:4dlu:noGrow"/>
                 <colspec value="fill:max(d;4px):noGrow"/>
                 <constraints>
-                  <grid row="5" column="0" row-span="1" col-span="7" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>
@@ -527,7 +527,7 @@
               <grid id="196b3" binding="redisSettingPane" layout-manager="GridLayoutManager" row-count="5" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="5" left="5" bottom="5" right="5"/>
                 <constraints>
-                  <grid row="3" column="0" row-span="1" col-span="7" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                  <grid row="3" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="0" height="50"/>
                   </grid>
                 </constraints>
@@ -566,7 +566,7 @@
                       <toolTipText value="redis password"/>
                     </properties>
                   </component>
-                  <component id="b6368" class="javax.swing.JPasswordField" binding="redisPasswordField">
+                  <component id="38181" class="javax.swing.JTextField" binding="redisPasswordField">
                     <constraints>
                       <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
@@ -691,7 +691,7 @@
               <grid id="622a6" binding="s3Panel" layout-manager="GridLayoutManager" row-count="9" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="5" left="5" bottom="5" right="5"/>
                 <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="7" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                  <grid row="2" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="0" height="51"/>
                   </grid>
                 </constraints>
@@ -729,7 +729,7 @@
                       <toolTipText value="yourAccessKeyId"/>
                     </properties>
                   </component>
-                  <component id="e1200" class="javax.swing.JPasswordField" binding="s3AkField">
+                  <component id="e5615" class="javax.swing.JTextField" binding="s3AkField">
                     <constraints>
                       <grid row="1" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
@@ -746,7 +746,7 @@
                       <toolTipText value="yourAccessKeySecret"/>
                     </properties>
                   </component>
-                  <component id="c771d" class="javax.swing.JPasswordField" binding="s3SkField">
+                  <component id="f9fa5" class="javax.swing.JTextField" binding="s3SkField">
                     <constraints>
                       <grid row="2" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>

--- a/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.java
+++ b/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.java
@@ -1,6 +1,7 @@
 package com.github.wangji92.arthas.plugin.ui;
 
 import com.aliyun.oss.OSS;
+import com.amazonaws.services.s3.AmazonS3;
 import com.github.wangji92.arthas.plugin.constants.ArthasCommandConstants;
 import com.github.wangji92.arthas.plugin.setting.AppSettingsState;
 import com.github.wangji92.arthas.plugin.utils.*;
@@ -222,7 +223,28 @@ public class AppSettingsPage implements Configurable {
     /**
      * 自动将中文转换为 unicode 编码
      */
-    private LinkLabel howToInputChinseParamLink;
+    private LinkLabel howToInputChineseParamLink;
+
+    private JRadioButton s3RadioButton;
+
+    private JTextField s3EndPointField;
+
+    private JPasswordField s3AkField;
+
+    private JPasswordField s3SkField;
+
+    private JTextField s3BucketNameField;
+
+    private JTextField s3DirPrefixField;
+
+    private JRadioButton s3GlobalConfigField;
+
+    private JTextField s3RegionField;
+
+    private JPanel s3Panel;
+
+    private JLabel s3CheckMessageLabel;
+    private JButton s3CheckButton;
 
 
     @Nls(capitalization = Nls.Capitalization.Title)
@@ -266,7 +288,7 @@ public class AppSettingsPage implements Configurable {
         this.arthasIdeaGithubLink = ActionLinkUtils.newActionLink("https://github.com/WangJi92/arthas-idea-plugin");
         this.arthasIdeaDemoLink = ActionLinkUtils.newActionLink("https://github.com/WangJi92/arthas-plugin-demo");
         this.arthasYuQueDocumentLink = ActionLinkUtils.newActionLink("https://www.yuque.com/arthas-idea-plugin");
-        this.howToInputChinseParamLink = ActionLinkUtils.newActionLink("https://github.com/alibaba/arthas/blob/master/site/src/site/sphinx/faq.md#%E8%BE%93%E5%85%A5%E4%B8%AD%E6%96%87unicode%E5%AD%97%E7%AC%A6");
+        this.howToInputChineseParamLink = ActionLinkUtils.newActionLink("https://github.com/alibaba/arthas/blob/master/site/src/site/sphinx/faq.md#%E8%BE%93%E5%85%A5%E4%B8%AD%E6%96%87unicode%E5%AD%97%E7%AC%A6");
 
     }
 
@@ -290,6 +312,7 @@ public class AppSettingsPage implements Configurable {
                 || springContextGlobalSettingRadioButton.isSelected() != settings.springContextGlobalSetting
                 || aliYunOssRadioButton.isSelected() != settings.aliYunOss
                 || redisRadioButton.isSelected() != settings.hotRedefineRedis
+                || s3RadioButton.isSelected() != settings.awsS3
                 || hotRedefineDeleteFileRadioButton.isSelected() != settings.hotRedefineDelete
                 || redefineBeforeCompileRadioButton.isSelected() != settings.redefineBeforeCompile
                 || printConditionExpressRadioButton.isSelected() != settings.printConditionExpress
@@ -308,6 +331,15 @@ public class AppSettingsPage implements Configurable {
                     || !settings.accessKeySecret.equals(String.valueOf(ossAccessKeySecretPasswordField.getPassword()))
                     || !settings.bucketName.equals(ossBucketNameTextField.getText())
                     || !settings.directoryPrefix.equals(ossDirectoryPrefixTextField.getText());
+        }
+
+        if (s3RadioButton.isSelected()) {
+            modify = !settings.s3Endpoint.equals(s3EndPointField.getText())
+                    || !settings.s3AccessKeyId.equals(String.valueOf(s3AkField.getPassword()))
+                    || !settings.s3AccessKeySecret.equals(String.valueOf(s3SkField.getPassword()))
+                    || !settings.s3BucketName.equals(s3BucketNameField.getText())
+                    || !settings.s3Region.equals(s3RegionField.getText())
+                    || !settings.s3DirectoryPrefix.equals(s3DirPrefixField.getText());
         }
 
         if (redisRadioButton.isSelected()) {
@@ -373,11 +405,14 @@ public class AppSettingsPage implements Configurable {
             settings.hotRedefineClipboard = true;
             settings.aliYunOss = false;
             settings.hotRedefineRedis = false;
+            settings.awsS3 = false;
             PropertiesComponentUtils.setValue("storageType", "hotRedefineClipboard");
         } else if (aliYunOssRadioButton.isSelected()) {
             this.saveAliyunOssConfig(error);
         } else if (redisRadioButton.isSelected()) {
             this.saveRedisConfig(error);
+        } else if (s3RadioButton.isSelected()) {
+            this.saveS3Config(error);
         }
 
         if (StringUtils.isNotBlank(error)) {
@@ -449,6 +484,8 @@ public class AppSettingsPage implements Configurable {
             settings.redisAuth = String.valueOf(redisPasswordField.getPassword());
             settings.hotRedefineRedis = true;
             settings.aliYunOss = false;
+            settings.awsS3 = false;
+            settings.hotRedefineClipboard = false;
             PropertiesComponentUtils.setValue("storageType", "hotRedefineRedis");
             PropertiesComponentUtils.setValue("redisAddress", settings.redisAddress);
             PropertiesComponentUtils.setValue("redisPort", "" + settings.redisPort);
@@ -477,6 +514,8 @@ public class AppSettingsPage implements Configurable {
             settings.directoryPrefix = ossDirectoryPrefixTextField.getText();
             settings.aliYunOss = true;
             settings.hotRedefineRedis = false;
+            settings.awsS3 = false;
+            settings.hotRedefineClipboard = false;
             settings.ossGlobalSetting = ossGlobalSettingRadioButton.isSelected();
             if (ossGlobalSettingRadioButton.isSelected()) {
                 PropertiesComponentUtils.setValue("storageType", "aliYunOss");
@@ -492,6 +531,50 @@ public class AppSettingsPage implements Configurable {
         } finally {
             if (oss != null) {
                 oss.shutdown();
+            }
+        }
+    }
+
+    /**
+     * aws3
+     *
+     * @param error
+     */
+    private void saveS3Config(StringBuilder error) {
+        AmazonS3 s3 = null;
+        try {
+            s3 = OsS3Utils.buildS3Client(s3EndPointField.getText(),
+                    String.valueOf(s3AkField.getPassword()),
+                    String.valueOf(s3SkField.getPassword()),
+                    s3BucketNameField.getText(),
+                    s3RegionField.getText(),
+                    s3DirPrefixField.getText());
+            OsS3Utils.checkBuckNameExist(s3BucketNameField.getText(), s3);
+            settings.s3Endpoint = s3EndPointField.getText();
+            settings.s3AccessKeyId = String.valueOf(s3AkField.getPassword());
+            settings.s3AccessKeySecret = String.valueOf(s3SkField.getPassword());
+            settings.s3BucketName = s3BucketNameField.getText();
+            settings.s3DirectoryPrefix = s3DirPrefixField.getText();
+            settings.s3Region = s3RegionField.getText();
+            settings.awsS3 = true;
+            settings.hotRedefineRedis = false;
+            settings.aliYunOss = false;
+            settings.hotRedefineClipboard = false;
+            settings.s3GlobalConfig = s3GlobalConfigField.isSelected();
+            if (s3GlobalConfigField.isSelected()) {
+                PropertiesComponentUtils.setValue("storageType", "awsS3");
+                PropertiesComponentUtils.setValue("s3Endpoint", settings.s3Endpoint);
+                PropertiesComponentUtils.setValue("s3AccessKeyId", settings.s3AccessKeyId);
+                PropertiesComponentUtils.setValue("s3AccessKeySecret", settings.s3AccessKeySecret);
+                PropertiesComponentUtils.setValue("s3BucketName", settings.s3BucketName);
+                PropertiesComponentUtils.setValue("s3DirectoryPrefix", settings.s3DirectoryPrefix);
+                PropertiesComponentUtils.setValue("s3Region", settings.s3Region);
+            }
+        } catch (Exception e) {
+            error.append(e.getMessage());
+        } finally {
+            if (s3 != null) {
+                s3.shutdown();
             }
         }
     }
@@ -524,21 +607,37 @@ public class AppSettingsPage implements Configurable {
         redisCacheKeyTtl.setValue(settings.redisCacheKeyTtl);
         redisCacheKeyTextField.setText(settings.redisCacheKey);
 
+        s3EndPointField.setText(settings.s3Endpoint);
+        s3AkField.setText(settings.s3AccessKeyId);
+        s3SkField.setText(settings.s3AccessKeySecret);
+        s3BucketNameField.setText(settings.s3BucketName);
+        s3DirPrefixField.setText(settings.s3DirectoryPrefix);
+        s3RegionField.setText(settings.s3Region);
+        s3GlobalConfigField.setSelected(settings.s3GlobalConfig);
+
         if (settings.aliYunOss) {
             // 阿里云oss
             aliYunOssRadioButton.setSelected(true);
             redisSettingPane.setVisible(false);
+            s3Panel.setVisible(false);
             aliyunOssSettingPane.setVisible(true);
         } else if (settings.hotRedefineRedis) {
             // redis
             aliyunOssSettingPane.setVisible(false);
             redisRadioButton.setSelected(true);
+            s3Panel.setVisible(false);
             redisSettingPane.setVisible(true);
+        } else if (settings.awsS3) {
+            s3RadioButton.setSelected(true);
+            redisSettingPane.setVisible(false);
+            s3Panel.setVisible(true);
+            aliyunOssSettingPane.setVisible(false);
         } else {
             // 剪切板
             clipboardRadioButton.setSelected(true);
             aliyunOssSettingPane.setVisible(false);
             redisSettingPane.setVisible(false);
+            s3Panel.setVisible(false);
         }
         if (settings.manualSelectPid) {
             preConfigurationSelectPidPanel.setVisible(false);
@@ -580,6 +679,29 @@ public class AppSettingsPage implements Configurable {
             }
         });
 
+        s3CheckButton.addActionListener(e -> {
+            AmazonS3 s3 = null;
+            try {
+                s3 = OsS3Utils.buildS3Client(s3EndPointField.getText(),
+                        String.valueOf(s3AkField.getPassword()),
+                        String.valueOf(s3SkField.getPassword()),
+                        s3BucketNameField.getText(),
+                        s3RegionField.getText(),
+                        s3DirPrefixField.getText());
+                OsS3Utils.checkBuckNameExist(s3BucketNameField.getText(), s3);
+                s3.shutdown();
+                s3CheckMessageLabel.setText("s3 setting check success");
+                s3CheckMessageLabel.setForeground(JBColor.BLACK);
+            } catch (Exception ex) {
+                s3CheckMessageLabel.setText(ex.getMessage());
+                s3CheckMessageLabel.setForeground(JBColor.RED);
+            } finally {
+                if (s3 != null) {
+                    s3.shutdown();
+                }
+            }
+        });
+
         redisCheckConfigButton.addActionListener(e -> {
             try (Jedis jedis = JedisUtils.buildJedisClient(redisAddressTextField.getText(), (Integer) redisPortField.getValue(), 5000, String.valueOf(redisPasswordField.getPassword()));) {
                 JedisUtils.checkRedisClient(jedis);
@@ -595,24 +717,33 @@ public class AppSettingsPage implements Configurable {
         group.add(aliYunOssRadioButton);
         group.add(clipboardRadioButton);
         group.add(redisRadioButton);
+        group.add(s3RadioButton);
         ItemListener itemListener = e -> {
             if (e.getSource().equals(aliYunOssRadioButton) && e.getStateChange() == ItemEvent.SELECTED) {
                 aliyunOssSettingPane.setVisible(true);
                 redisSettingPane.setVisible(false);
+                s3Panel.setVisible(false);
             } else if (e.getSource().equals(clipboardRadioButton) && e.getStateChange() == ItemEvent.SELECTED) {
                 aliyunOssSettingPane.setVisible(false);
                 redisSettingPane.setVisible(false);
-
+                s3Panel.setVisible(false);
             } else if (e.getSource().equals(redisRadioButton) && e.getStateChange() == ItemEvent.SELECTED) {
                 aliyunOssSettingPane.setVisible(false);
                 redisSettingPane.setVisible(true);
+                s3Panel.setVisible(false);
+            } else if (e.getSource().equals(s3RadioButton) && e.getStateChange() == ItemEvent.SELECTED) {
+                aliyunOssSettingPane.setVisible(false);
+                redisSettingPane.setVisible(false);
+                s3Panel.setVisible(true);
             }
             ossCheckMsgLabel.setText("");
             redisMessageLabel.setText("");
+            s3CheckMessageLabel.setText("");
         };
         aliYunOssRadioButton.addItemListener(itemListener);
         clipboardRadioButton.addItemListener(itemListener);
         redisRadioButton.addItemListener(itemListener);
+        s3RadioButton.addItemListener(itemListener);
 
         // 设置是否手动选择pid
         ItemListener itemListenerSelectPid = e -> {

--- a/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.java
+++ b/src/com/github/wangji92/arthas/plugin/ui/AppSettingsPage.java
@@ -94,11 +94,11 @@ public class AppSettingsPage implements Configurable {
     /**
      * oss 配置信息 AccessKeyId
      */
-    private JPasswordField ossAccessKeyIdPasswordField;
+    private JTextField ossAccessKeyIdPasswordField;
     /**
      * oss 配置信息 AccessKeySecret
      */
-    private JPasswordField ossAccessKeySecretPasswordField;
+    private JTextField ossAccessKeySecretPasswordField;
     /**
      * oss 配置信息 DirectoryPrefix
      */
@@ -162,7 +162,7 @@ public class AppSettingsPage implements Configurable {
     /**
      * redis 密码
      */
-    private JPasswordField redisPasswordField;
+    private JTextField redisPasswordField;
     /**
      * redis 检测 button
      */
@@ -229,9 +229,9 @@ public class AppSettingsPage implements Configurable {
 
     private JTextField s3EndPointField;
 
-    private JPasswordField s3AkField;
+    private JTextField s3AkField;
 
-    private JPasswordField s3SkField;
+    private JTextField s3SkField;
 
     private JTextField s3BucketNameField;
 
@@ -327,16 +327,16 @@ public class AppSettingsPage implements Configurable {
         }
         if (aliYunOssRadioButton.isSelected()) {
             modify = !settings.endpoint.equals(ossEndpointTextField.getText())
-                    || !settings.accessKeyId.equals(String.valueOf(ossAccessKeyIdPasswordField.getPassword()))
-                    || !settings.accessKeySecret.equals(String.valueOf(ossAccessKeySecretPasswordField.getPassword()))
+                    || !settings.accessKeyId.equals(String.valueOf(ossAccessKeyIdPasswordField.getText()))
+                    || !settings.accessKeySecret.equals(String.valueOf(ossAccessKeySecretPasswordField.getText()))
                     || !settings.bucketName.equals(ossBucketNameTextField.getText())
                     || !settings.directoryPrefix.equals(ossDirectoryPrefixTextField.getText());
         }
 
         if (s3RadioButton.isSelected()) {
             modify = !settings.s3Endpoint.equals(s3EndPointField.getText())
-                    || !settings.s3AccessKeyId.equals(String.valueOf(s3AkField.getPassword()))
-                    || !settings.s3AccessKeySecret.equals(String.valueOf(s3SkField.getPassword()))
+                    || !settings.s3AccessKeyId.equals(String.valueOf(s3AkField.getText()))
+                    || !settings.s3AccessKeySecret.equals(String.valueOf(s3SkField.getText()))
                     || !settings.s3BucketName.equals(s3BucketNameField.getText())
                     || !settings.s3Region.equals(s3RegionField.getText())
                     || !settings.s3DirectoryPrefix.equals(s3DirPrefixField.getText());
@@ -345,7 +345,7 @@ public class AppSettingsPage implements Configurable {
         if (redisRadioButton.isSelected()) {
             modify = !settings.redisAddress.equals(redisAddressTextField.getText())
                     || !settings.redisPort.equals((redisPortField.getValue()))
-                    || !settings.redisAuth.equals(String.valueOf(redisPasswordField.getPassword()))
+                    || !settings.redisAuth.equals(String.valueOf(redisPasswordField.getText()))
                     || !settings.redisCacheKey.equals(redisCacheKeyTextField.getText())
                     || !settings.redisCacheKeyTtl.equals(redisCacheKeyTtl.getValue());
         }
@@ -477,11 +477,11 @@ public class AppSettingsPage implements Configurable {
         if (StringUtils.isBlank(redisCacheKeyTextField.getText())) {
             settings.redisCacheKey = "arthasIdeaPluginRedefineCacheKey";
         }
-        try (Jedis jedis = JedisUtils.buildJedisClient(redisAddressTextField.getText(), (Integer) redisPortField.getValue(), 5000, String.valueOf(redisPasswordField.getPassword()));) {
+        try (Jedis jedis = JedisUtils.buildJedisClient(redisAddressTextField.getText(), (Integer) redisPortField.getValue(), 5000, String.valueOf(redisPasswordField.getText()));) {
             JedisUtils.checkRedisClient(jedis);
             settings.redisAddress = redisAddressTextField.getText();
             settings.redisPort = (Integer) redisPortField.getValue();
-            settings.redisAuth = String.valueOf(redisPasswordField.getPassword());
+            settings.redisAuth = String.valueOf(redisPasswordField.getText());
             settings.hotRedefineRedis = true;
             settings.aliYunOss = false;
             settings.awsS3 = false;
@@ -505,11 +505,11 @@ public class AppSettingsPage implements Configurable {
     private void saveAliyunOssConfig(StringBuilder error) {
         OSS oss = null;
         try {
-            oss = AliyunOssUtils.buildOssClient(ossEndpointTextField.getText(), String.valueOf(ossAccessKeyIdPasswordField.getPassword()), String.valueOf(ossAccessKeySecretPasswordField.getPassword()), ossBucketNameTextField.getText(), ossDirectoryPrefixTextField.getText());
+            oss = AliyunOssUtils.buildOssClient(ossEndpointTextField.getText(), String.valueOf(ossAccessKeyIdPasswordField.getText()), String.valueOf(ossAccessKeySecretPasswordField.getText()), ossBucketNameTextField.getText(), ossDirectoryPrefixTextField.getText());
             AliyunOssUtils.checkBuckNameExist(ossBucketNameTextField.getText(), oss);
             settings.endpoint = ossEndpointTextField.getText();
-            settings.accessKeyId = String.valueOf(ossAccessKeyIdPasswordField.getPassword());
-            settings.accessKeySecret = String.valueOf(ossAccessKeySecretPasswordField.getPassword());
+            settings.accessKeyId = String.valueOf(ossAccessKeyIdPasswordField.getText());
+            settings.accessKeySecret = String.valueOf(ossAccessKeySecretPasswordField.getText());
             settings.bucketName = ossBucketNameTextField.getText();
             settings.directoryPrefix = ossDirectoryPrefixTextField.getText();
             settings.aliYunOss = true;
@@ -544,15 +544,15 @@ public class AppSettingsPage implements Configurable {
         AmazonS3 s3 = null;
         try {
             s3 = OsS3Utils.buildS3Client(s3EndPointField.getText(),
-                    String.valueOf(s3AkField.getPassword()),
-                    String.valueOf(s3SkField.getPassword()),
+                    String.valueOf(s3AkField.getText()),
+                    String.valueOf(s3SkField.getText()),
                     s3BucketNameField.getText(),
                     s3RegionField.getText(),
                     s3DirPrefixField.getText());
             OsS3Utils.checkBuckNameExist(s3BucketNameField.getText(), s3);
             settings.s3Endpoint = s3EndPointField.getText();
-            settings.s3AccessKeyId = String.valueOf(s3AkField.getPassword());
-            settings.s3AccessKeySecret = String.valueOf(s3SkField.getPassword());
+            settings.s3AccessKeyId = String.valueOf(s3AkField.getText());
+            settings.s3AccessKeySecret = String.valueOf(s3SkField.getText());
             settings.s3BucketName = s3BucketNameField.getText();
             settings.s3DirectoryPrefix = s3DirPrefixField.getText();
             settings.s3Region = s3RegionField.getText();
@@ -664,7 +664,7 @@ public class AppSettingsPage implements Configurable {
         ossSettingCheckButton.addActionListener(e -> {
             OSS oss = null;
             try {
-                oss = AliyunOssUtils.buildOssClient(ossEndpointTextField.getText(), String.valueOf(ossAccessKeyIdPasswordField.getPassword()), String.valueOf(ossAccessKeySecretPasswordField.getPassword()), ossBucketNameTextField.getText(), ossDirectoryPrefixTextField.getText());
+                oss = AliyunOssUtils.buildOssClient(ossEndpointTextField.getText(), String.valueOf(ossAccessKeyIdPasswordField.getText()), String.valueOf(ossAccessKeySecretPasswordField.getText()), ossBucketNameTextField.getText(), ossDirectoryPrefixTextField.getText());
                 AliyunOssUtils.checkBuckNameExist(ossBucketNameTextField.getText(), oss);
                 oss.shutdown();
                 ossCheckMsgLabel.setText("oss setting check success");
@@ -683,8 +683,8 @@ public class AppSettingsPage implements Configurable {
             AmazonS3 s3 = null;
             try {
                 s3 = OsS3Utils.buildS3Client(s3EndPointField.getText(),
-                        String.valueOf(s3AkField.getPassword()),
-                        String.valueOf(s3SkField.getPassword()),
+                        String.valueOf(s3AkField.getText()),
+                        String.valueOf(s3SkField.getText()),
                         s3BucketNameField.getText(),
                         s3RegionField.getText(),
                         s3DirPrefixField.getText());
@@ -703,7 +703,7 @@ public class AppSettingsPage implements Configurable {
         });
 
         redisCheckConfigButton.addActionListener(e -> {
-            try (Jedis jedis = JedisUtils.buildJedisClient(redisAddressTextField.getText(), (Integer) redisPortField.getValue(), 5000, String.valueOf(redisPasswordField.getPassword()));) {
+            try (Jedis jedis = JedisUtils.buildJedisClient(redisAddressTextField.getText(), (Integer) redisPortField.getValue(), 5000, String.valueOf(redisPasswordField.getText()));) {
                 JedisUtils.checkRedisClient(jedis);
                 redisMessageLabel.setText("redis setting check success");
                 redisMessageLabel.setForeground(JBColor.BLACK);

--- a/src/com/github/wangji92/arthas/plugin/utils/DirectScriptUtils.java
+++ b/src/com/github/wangji92/arthas/plugin/utils/DirectScriptUtils.java
@@ -111,7 +111,7 @@ public class DirectScriptUtils {
             LOG.error("upload  to clipboard error", e);
         }
         StringBuilder tipsBuilder = new StringBuilder("linux shell command has been copied to the clipboard Go to the server and paste it without open arthas");
-        tipsBuilder.append("[No storage configuration The execution script is long, recommend to configure Ali cloud oss or redis]");
+        tipsBuilder.append("[No storage configuration The execution script is long, recommend to configure Ali cloud oss or S3 or redis]");
 
         DirectScriptResult directScriptResult = new DirectScriptResult();
         directScriptResult.setResult(result);

--- a/src/com/github/wangji92/arthas/plugin/utils/DirectScriptUtils.java
+++ b/src/com/github/wangji92/arthas/plugin/utils/DirectScriptUtils.java
@@ -38,7 +38,7 @@ public class DirectScriptUtils {
     /**
      * redis
      */
-    private static final String REDIS_HOT_REDEFINE = "echo `redis-cli -h '%s' -p '%s'  get %s` ";
+    private static final String REDIS_HOT_REDEFINE = "echo `redis-cli -h '%s' -p %s  get %s` ";
 
 
     /**
@@ -134,7 +134,7 @@ public class DirectScriptUtils {
 
             StringBuilder portAndAuth = new StringBuilder("" + settings.redisPort);
             if (!StringUtils.isBlank(settings.redisAuth)) {
-                portAndAuth.append(" -a ").append(settings.redisAuth);
+                portAndAuth.append(" -a '").append(settings.redisAuth).append("'");
             }
 
             String cacheKey = settings.redisCacheKey + "_" + UUID.randomUUID().toString();

--- a/src/com/github/wangji92/arthas/plugin/utils/DirectScriptUtils.java
+++ b/src/com/github/wangji92/arthas/plugin/utils/DirectScriptUtils.java
@@ -1,6 +1,7 @@
 package com.github.wangji92.arthas.plugin.utils;
 
 import com.aliyun.oss.OSS;
+import com.amazonaws.services.s3.AmazonS3;
 import com.github.wangji92.arthas.plugin.setting.AppSettingsState;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.diagnostic.Logger;
@@ -82,6 +83,8 @@ public class DirectScriptUtils {
     public static void buildDirectScript(Project project, AppSettingsState settings, String base64ShelText, String shellFileName, Consumer<DirectScriptResult> consumer) {
         if (settings.aliYunOss) {
             DirectScriptUtils.uploadBase64FileToOss(project, settings, base64ShelText, shellFileName, consumer);
+        } else if (settings.awsS3) {
+            DirectScriptUtils.uploadBase64FileToS3(project, settings, base64ShelText, shellFileName, consumer);
         } else if (settings.hotRedefineRedis) {
             DirectScriptUtils.uploadBase64FileToRedis(project, settings, base64ShelText, shellFileName, consumer);
         } else {
@@ -181,6 +184,43 @@ public class DirectScriptUtils {
         } finally {
             if (oss != null) {
                 oss.shutdown();
+            }
+        }
+
+        StringBuilder tipsBuilder = new StringBuilder("linux shell command has been copied to the clipboard Go to the server and paste it without open arthas");
+        DirectScriptResult directScriptResult = new DirectScriptResult();
+        directScriptResult.setResult(result);
+        directScriptResult.setTip(tipsBuilder);
+        consumer.accept(directScriptResult);
+    }
+
+    /**
+     * 上传热更新 文件到oss
+     *
+     * @param project
+     * @param settings
+     * @param base64RedefineSh
+     * @param shellFileName
+     * @param consumer
+     */
+    private static void uploadBase64FileToS3(Project project, AppSettingsState settings, String base64RedefineSh, String shellFileName, Consumer<DirectScriptResult> consumer) {
+        boolean result = true;
+        AmazonS3 s3 = null;
+        try {
+            s3 = OsS3Utils.buildS3Client(project);
+            String filePathKey = settings.s3DirectoryPrefix + UUID.randomUUID().toString();
+            String urlEncodeKeyPath = OsS3Utils.putFile(s3, settings.s3BucketName, filePathKey, base64RedefineSh);
+            String presignedUrl = OsS3Utils.generatePresignedUrl(s3, settings.s3BucketName, urlEncodeKeyPath, new Date(System.currentTimeMillis() + 3600L * 1000));
+            String command = String.format(OSS_HOT_REDEFINE, presignedUrl);
+            String finalCommand = String.format(BASE_64_TO_SHELL, command, shellFileName, shellFileName, shellFileName);
+            ClipboardUtils.setClipboardString(finalCommand);
+        } catch (Exception e) {
+            LOG.error("upload to s3 error", e);
+            NotifyUtils.notifyMessage(project, "Failed to upload file to s3" + e.getMessage(), NotificationType.ERROR);
+            result = false;
+        } finally {
+            if (s3 != null) {
+                s3.shutdown();
             }
         }
 

--- a/src/com/github/wangji92/arthas/plugin/utils/OsS3Utils.java
+++ b/src/com/github/wangji92/arthas/plugin/utils/OsS3Utils.java
@@ -1,0 +1,169 @@
+package com.github.wangji92.arthas.plugin.utils;
+
+
+import com.aliyun.oss.internal.OSSUtils;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.github.wangji92.arthas.plugin.setting.AppSettingsState;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Date;
+
+
+/**
+ * aws s3 本地使用 mini io
+ * http://docs.minio.org.cn/docs/master/how-to-use-aws-sdk-for-java-with-minio-server
+ *
+ * @author 汪小哥
+ * @date 16-10-2022
+ */
+public class OsS3Utils {
+    private static final Logger LOG = Logger.getInstance(OsS3Utils.class);
+
+    /**
+     * 获取oss 客户端
+     *
+     * @return
+     */
+    public static AmazonS3 buildOssClient(String endpoint, String accessKeyId, String accessKeySecret, String bucketName, String region, String directoryPrefix) {
+        if (StringUtils.isBlank(endpoint)) {
+            throw new IllegalArgumentException("配置arthas os s3 endpoint Error");
+        }
+        if (StringUtils.isBlank(accessKeyId)) {
+            throw new IllegalArgumentException("配置arthas os s3 accessKeyId Error");
+        }
+        if (StringUtils.isBlank(accessKeySecret)) {
+            throw new IllegalArgumentException("配置arthas os s3 accessKeySecret Error");
+        }
+        if (StringUtils.isBlank(bucketName) || !OSSUtils.validateBucketName(bucketName)) {
+            throw new IllegalArgumentException("配置arthas s3  bucketName Error");
+        }
+        // 校验key的信息
+        if (StringUtils.isNotBlank(directoryPrefix) && !OSSUtils.validateObjectKey(OSSUtils.makeResourcePath(directoryPrefix))) {
+            throw new IllegalArgumentException("配置arthas  s3 directoryPrefix Error");
+        }
+        AWSCredentials credentials = new BasicAWSCredentials(accessKeyId, accessKeySecret);
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+        return AmazonS3ClientBuilder
+                .standard()
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
+                .withPathStyleAccessEnabled(true)
+                .withClientConfiguration(clientConfiguration)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+
+    public static AmazonS3 buildOssClient(Project project) {
+        AppSettingsState instance = AppSettingsState.getInstance(project);
+        if (!instance.awsS3) {
+            throw new IllegalArgumentException("配置arthas idea plugin Hot Redefine Setting 阿里云oss");
+        }
+        return buildOssClient(instance.endpoint, instance.accessKeyId, instance.accessKeySecret, instance.bucketName, "", instance.directoryPrefix);
+    }
+
+    /**
+     * 检查是否存在
+     *
+     * @param bucketName
+     * @param s3Client
+     */
+    public static void checkBuckNameExist(String bucketName, AmazonS3 s3Client) {
+        // 检查是否存在
+        try {
+            boolean bucketExistV2 = s3Client.doesBucketExistV2(bucketName);
+            if (!bucketExistV2) {
+                throw new IllegalArgumentException("配置s3 无法获取 bucketName");
+            }
+        } catch (Exception e) {
+            LOG.info("checkBuckNameExist", e);
+            throw new IllegalArgumentException("配置s3 无法获取 bucketName " + e.getMessage());
+        }
+    }
+
+    /**
+     * 上传文件流
+     *
+     * @param s3
+     * @param filePath xxxPath/xxxFile.jpg
+     * @return 返回 oss key的信息
+     */
+    public static String putFile(AmazonS3 s3, String bucketName, String filePath, InputStream inputStream) {
+
+        String urlEncodeKeyPath = OSSUtils.makeResourcePath(filePath);
+        if (!OSSUtils.validateObjectKey(OSSUtils.makeResourcePath(filePath))) {
+            throw new IllegalArgumentException("配置arthas 对象存储 上传错误 fileKey 错误");
+        }
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType("application/octet-stream");
+        PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, urlEncodeKeyPath, inputStream, objectMetadata);
+        try {
+            s3.putObject(putObjectRequest);
+        } catch (Exception e) {
+            LOG.info("putFile", e);
+            throw new IllegalArgumentException("上传文件到对象存储错误",e);
+        }
+
+        return urlEncodeKeyPath;
+    }
+
+    /**
+     * 上传字符串到oss
+     *
+     * @param ossClient
+     * @param bucketName
+     * @param filePath
+     * @param content
+     * @return
+     */
+    public static String putFile(AmazonS3 ossClient, String bucketName, String filePath, String content) {
+        return putFile(ossClient, bucketName, filePath, new ByteArrayInputStream(content.getBytes()));
+    }
+
+
+    /**
+     * Generates a signed url for accessing the {@link AmazonS3} with HTTP GET method.
+     *
+     * @param ossClient
+     * @param bucketName
+     * @param key
+     * @param expiration
+     * @return
+     */
+    public static String generatePresignedUrl(AmazonS3 ossClient, String bucketName, String key, Date expiration) {
+        if (expiration == null) {
+            expiration = new Date(System.currentTimeMillis() + 3600L * 1000);
+        }
+        try {
+            URL url = ossClient.generatePresignedUrl(bucketName, key, expiration);
+            return url.toString();
+        } catch (Exception e) {
+            LOG.info("generatePresignedUrl", e);
+            throw new IllegalArgumentException("获取对象存储 文件错误");
+        }
+    }
+
+//    public static void main(String[] args) throws FileNotFoundException {
+//        AmazonS3 amazonS3 = OsS3Utils.buildOssClient("http://localhost:9000",
+//                "Ez0doWOOZpmWM17x", "eSf1TGTPCdn4mtUT2i8aO8m2uvbVYSYj",
+//                "demo", "test-region", "arthas/");
+//
+//        OsS3Utils.checkBuckNameExist("demo",amazonS3);
+//
+//        OsS3Utils.putFile(amazonS3, "demo", "arthas/" + UUID.randomUUID().toString(),
+//                new FileInputStream(new File("/Users/wangji/Documents/project/arthas-idea-plugin/arthas-idea-plugin.zip")));
+//
+//    }
+
+
+}

--- a/src/com/github/wangji92/arthas/plugin/utils/OsS3Utils.java
+++ b/src/com/github/wangji92/arthas/plugin/utils/OsS3Utils.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Date;
+import java.util.UUID;
 
 
 /**
@@ -36,7 +37,7 @@ public class OsS3Utils {
      *
      * @return
      */
-    public static AmazonS3 buildOssClient(String endpoint, String accessKeyId, String accessKeySecret, String bucketName, String region, String directoryPrefix) {
+    public static AmazonS3 buildS3Client(String endpoint, String accessKeyId, String accessKeySecret, String bucketName, String region, String directoryPrefix) {
         if (StringUtils.isBlank(endpoint)) {
             throw new IllegalArgumentException("配置arthas os s3 endpoint Error");
         }
@@ -64,12 +65,13 @@ public class OsS3Utils {
                 .build();
     }
 
-    public static AmazonS3 buildOssClient(Project project) {
+    public static AmazonS3 buildS3Client(Project project) {
         AppSettingsState instance = AppSettingsState.getInstance(project);
         if (!instance.awsS3) {
             throw new IllegalArgumentException("配置arthas idea plugin Hot Redefine Setting 阿里云oss");
         }
-        return buildOssClient(instance.endpoint, instance.accessKeyId, instance.accessKeySecret, instance.bucketName, "", instance.directoryPrefix);
+        return buildS3Client(instance.s3Endpoint, instance.s3AccessKeyId, instance.s3AccessKeySecret, instance.s3BucketName, instance.s3Region,
+                instance.s3DirectoryPrefix);
     }
 
     /**
@@ -81,10 +83,7 @@ public class OsS3Utils {
     public static void checkBuckNameExist(String bucketName, AmazonS3 s3Client) {
         // 检查是否存在
         try {
-            boolean bucketExistV2 = s3Client.doesBucketExistV2(bucketName);
-            if (!bucketExistV2) {
-                throw new IllegalArgumentException("配置s3 无法获取 bucketName");
-            }
+            putFile(s3Client, bucketName, "arthas/" + UUID.randomUUID().toString(), "this is test");
         } catch (Exception e) {
             LOG.info("checkBuckNameExist", e);
             throw new IllegalArgumentException("配置s3 无法获取 bucketName " + e.getMessage());
@@ -111,7 +110,7 @@ public class OsS3Utils {
             s3.putObject(putObjectRequest);
         } catch (Exception e) {
             LOG.info("putFile", e);
-            throw new IllegalArgumentException("上传文件到对象存储错误",e);
+            throw new IllegalArgumentException("上传文件到对象存储错误", e);
         }
 
         return urlEncodeKeyPath;

--- a/src/com/github/wangji92/arthas/plugin/utils/OsS3Utils.java
+++ b/src/com/github/wangji92/arthas/plugin/utils/OsS3Utils.java
@@ -68,7 +68,7 @@ public class OsS3Utils {
     public static AmazonS3 buildS3Client(Project project) {
         AppSettingsState instance = AppSettingsState.getInstance(project);
         if (!instance.awsS3) {
-            throw new IllegalArgumentException("配置arthas idea plugin Hot Redefine Setting 阿里云oss");
+            throw new IllegalArgumentException("arthas idea plugin object Object Storage Setting s3");
         }
         return buildS3Client(instance.s3Endpoint, instance.s3AccessKeyId, instance.s3AccessKeySecret, instance.s3BucketName, instance.s3Region,
                 instance.s3DirectoryPrefix);

--- a/src/com/github/wangji92/arthas/plugin/utils/OsS3Utils.java
+++ b/src/com/github/wangji92/arthas/plugin/utils/OsS3Utils.java
@@ -19,7 +19,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Date;
-import java.util.UUID;
 
 
 /**
@@ -83,10 +82,12 @@ public class OsS3Utils {
     public static void checkBuckNameExist(String bucketName, AmazonS3 s3Client) {
         // 检查是否存在
         try {
-            putFile(s3Client, bucketName, "arthas/" + UUID.randomUUID().toString(), "this is test");
+            if (!s3Client.doesBucketExistV2(bucketName)) {
+                throw new IllegalArgumentException("s3 bucketName not found");
+            }
         } catch (Exception e) {
             LOG.info("checkBuckNameExist", e);
-            throw new IllegalArgumentException("配置s3 无法获取 bucketName " + e.getMessage());
+            throw new IllegalArgumentException("s3 bucketName not found" + e.getMessage());
         }
     }
 
@@ -148,7 +149,7 @@ public class OsS3Utils {
             return url.toString();
         } catch (Exception e) {
             LOG.info("generatePresignedUrl", e);
-            throw new IllegalArgumentException("获取对象存储 文件错误");
+            throw new IllegalArgumentException("generatePresignedUrl error",e);
         }
     }
 


### PR DESCRIPTION
* 静态脚本里面增加常用快捷脚本，eg 观察spring http请求耗时、观察jdbc 执行的sql 
* 动态脚本比如热更新、快捷shell 脚本、上传本地文件等功能都需要对象存储存储脚本内容,之前只支持 redis 、剪切板、 阿里云oss aws s3 很多厂商都支持 比如minio、华为云、腾讯云等等