### PR TITLE
Feature/support different jsonparse

### DIFF
--- a/.idea/libraries/alibaba_fastjson.xml
+++ b/.idea/libraries/alibaba_fastjson.xml
@@ -1,0 +1,12 @@
+<component name="libraryTable">
+  <library name="alibaba.fastjson" type="repository">
+    <properties maven-id="com.alibaba:fastjson:1.2.83" />
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/alibaba/fastjson/1.2.83/fastjson-1.2.83.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/alibaba/fastjson/1.2.83/fastjson-1.2.83-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/alibaba_fastjson2.xml
+++ b/.idea/libraries/alibaba_fastjson2.xml
@@ -1,0 +1,12 @@
+<component name="libraryTable">
+  <library name="alibaba.fastjson2" type="repository">
+    <properties maven-id="com.alibaba.fastjson2:fastjson2:2.0.49" />
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/alibaba/fastjson2/fastjson2/2.0.49/fastjson2-2.0.49.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/alibaba/fastjson2/fastjson2/2.0.49/fastjson2-2.0.49-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/arthas-idea-plugin.iml
+++ b/arthas-idea-plugin.iml
@@ -18,5 +18,7 @@
     <orderEntry type="library" name="redis.clients:jedis:3.4.1" level="project" />
     <orderEntry type="library" name="com.amazonaws:aws-java-sdk-s3:1.12.321" level="project" />
     <orderEntry type="library" name="reflections" level="project" />
+    <orderEntry type="library" name="alibaba.fastjson2" level="project" />
+    <orderEntry type="library" name="alibaba.fastjson" level="project" />
   </component>
 </module>

--- a/src/com/github/idea/json/parser/PsiParserToJson.java
+++ b/src/com/github/idea/json/parser/PsiParserToJson.java
@@ -71,6 +71,14 @@ public class PsiParserToJson {
         } else if (psiElement instanceof PsiField field) {
             return toJSONString(field.getType(),true);
         } else if (psiElement instanceof PsiMethod psiMethod) {
+            // 构造函数特殊处理
+            if (psiMethod.isConstructor()) {
+                PsiClass containingClass = psiMethod.getContainingClass();
+                if (containingClass !=null) {
+                    PsiType psiType = PsiToolkit.getPsiTypeByPisClazz(containingClass);
+                    return toJSONString(psiType,true);
+                }
+            }
             // 如果是方法、获取返回值的JSON 数据结构
             PsiType returnType = psiMethod.getReturnType();
             if (returnType != null) {

--- a/src/com/github/idea/json/parser/action/CopyJsonAction.java
+++ b/src/com/github/idea/json/parser/action/CopyJsonAction.java
@@ -2,10 +2,7 @@ package com.github.idea.json.parser.action;
 
 import com.github.idea.json.parser.PsiParserToJson;
 import com.github.idea.json.parser.toolkit.ParserContext;
-import com.github.wangji92.arthas.plugin.utils.ClipboardUtils;
-import com.github.wangji92.arthas.plugin.utils.NotifyUtils;
-import com.github.wangji92.arthas.plugin.utils.OgnlPsUtils;
-import com.github.wangji92.arthas.plugin.utils.StringUtils;
+import com.github.wangji92.arthas.plugin.utils.*;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.psi.*;
@@ -76,7 +73,8 @@ public class CopyJsonAction extends AnAction {
         DataContext dataContext = e.getDataContext();
         PsiElement psiElement = CommonDataKeys.PSI_ELEMENT.getData(dataContext);
         assert psiElement != null;
-
+        OgnlJsonHandlerUtils.JsonType jsonType = OgnlJsonHandlerUtils.getJsonType(e.getProject());
+        parserContext.setJsonType(jsonType.getType());
         String jsonString = PsiParserToJson.getInstance().toJSONString(psiElement,parserContext);
         if (StringUtils.isBlank(jsonString)) {
             String emptyData = "JSON data empty";

--- a/src/com/github/idea/json/parser/action/CopyJsonAction.java
+++ b/src/com/github/idea/json/parser/action/CopyJsonAction.java
@@ -1,6 +1,7 @@
 package com.github.idea.json.parser.action;
 
 import com.github.idea.json.parser.PsiParserToJson;
+import com.github.idea.json.parser.toolkit.ParserContext;
 import com.github.wangji92.arthas.plugin.utils.ClipboardUtils;
 import com.github.wangji92.arthas.plugin.utils.NotifyUtils;
 import com.github.wangji92.arthas.plugin.utils.OgnlPsUtils;
@@ -59,12 +60,24 @@ public class CopyJsonAction extends AnAction {
         e.getPresentation().setEnabled(false);
     }
 
+    /**
+     * 解析上下文
+     */
+    private static ParserContext parserContext;
+
+    static {
+        parserContext = new ParserContext();
+        parserContext.setPretty(true);
+        parserContext.setJsonType(ParserContext.ParserJsonType.FASTJSON);
+    }
+
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         DataContext dataContext = e.getDataContext();
         PsiElement psiElement = CommonDataKeys.PSI_ELEMENT.getData(dataContext);
         assert psiElement != null;
-        String jsonString = PsiParserToJson.getInstance().toJSONString(psiElement);
+
+        String jsonString = PsiParserToJson.getInstance().toJSONString(psiElement,parserContext);
         if (StringUtils.isBlank(jsonString)) {
             String emptyData = "JSON data empty";
             ClipboardUtils.setClipboardString("{}");

--- a/src/com/github/idea/json/parser/toolkit/ParserContext.java
+++ b/src/com/github/idea/json/parser/toolkit/ParserContext.java
@@ -1,0 +1,103 @@
+package com.github.idea.json.parser.toolkit;
+
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import com.alibaba.fastjson2.JSONWriter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.intellij.openapi.diagnostic.Logger;
+import lombok.Data;
+
+/**
+ * 解析上下文 (为了保证json 序列化和反序列化一致性，需要感知ognl 使用的哪种json工具)
+ *
+ * @author wangji
+ * @date 2024/5/29 23:01
+ */
+@Data
+public class ParserContext {
+
+    private static final Logger LOG = Logger.getInstance(ParserContext.class);
+
+    private ParserJsonType jsonType;
+
+    private Boolean pretty = true;
+
+    /**
+     * 解析JSON的类型
+     */
+    public static enum ParserJsonType {
+        FASTJSON {
+            @Override
+            public String toJsonString(Object object, ParserContext parserContext) {
+                if (Boolean.TRUE.equals(parserContext.getPretty())) {
+                    return com.alibaba.fastjson.JSON.toJSONString(object, SerializerFeature.PrettyFormat);
+                }
+                return com.alibaba.fastjson.JSON.toJSONString(object);
+            }
+        },
+        FASTJSON_2 {
+            @Override
+            public String toJsonString(Object object, ParserContext parserContext) {
+                if (Boolean.TRUE.equals(parserContext.getPretty())) {
+                    return com.alibaba.fastjson2.JSON.toJSONString(object, JSONWriter.Feature.PrettyFormat);
+                }
+                return com.alibaba.fastjson2.JSON.toJSONString(object);
+            }
+        },
+        JACKSON {
+            private final static ObjectMapper OBJECTMAPPER = new ObjectMapper()
+                    .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+
+            @Override
+            public String toJsonString(Object object, ParserContext parserContext) {
+                try {
+                    if (Boolean.TRUE.equals(parserContext.getPretty())) {
+                        return OBJECTMAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(object);
+                    }
+                    return OBJECTMAPPER.writeValueAsString(object);
+                } catch (Exception e) {
+                    LOG.error("parse json error", e);
+                }
+                return null;
+            }
+        },
+        GSON {
+            private final static Gson GSON_PRETTY = new GsonBuilder().setPrettyPrinting().create();
+
+            private final static Gson GSON = new GsonBuilder().create();
+
+            @Override
+            public String toJsonString(Object object, ParserContext parserContext) {
+                if (Boolean.TRUE.equals(parserContext.getPretty())) {
+                    return GSON_PRETTY.toJson(object);
+                }
+                return GSON.toJson(object);
+            }
+        };
+
+        /**
+         * 获取模板
+         *
+         * @return
+         */
+        public abstract String toJsonString(Object object, ParserContext parserContext);
+    }
+
+    /**
+     * 解析JSON字符串
+     *
+     * @param object
+     * @return
+     */
+    public String toJsonString(Object object) {
+        if (this.getJsonType() != null) {
+            return this.getJsonType().toJsonString(object, this);
+        }
+        return null;
+    }
+
+}

--- a/src/com/github/idea/json/parser/typevalue/jdk/common/JavaPathTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/common/JavaPathTypeValue.java
@@ -12,7 +12,7 @@ import java.nio.file.Path;
 public class JavaPathTypeValue implements TypeDefaultValue {
     @Override
     public Object getValue(TypeValueContext context) {
-        return"file://home/user";
+        return null;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/common/multi/JdkAnalysisInheritanceTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/common/multi/JdkAnalysisInheritanceTypeValue.java
@@ -3,7 +3,6 @@ package com.github.idea.json.parser.typevalue.jdk.common.multi;
 import com.github.idea.json.parser.typevalue.MultiTypeDefaultValue;
 import com.github.idea.json.parser.typevalue.TypeDefaultValue;
 import com.github.idea.json.parser.typevalue.TypeValueContext;
-import com.github.idea.json.parser.typevalue.jdk.time.ZonedDateTimeTypeValue;
 import com.intellij.psi.PsiType;
 
 import java.math.BigDecimal;
@@ -37,7 +36,7 @@ public class JdkAnalysisInheritanceTypeValue implements MultiTypeDefaultValue {
         Map<String, Object> container = this.getContainer();
         container.put(Number.class.getName(), 0);
         container.put(CharSequence.class.getName(), " ");
-        container.put(BigDecimal.class.getName(), 0.0);
+        container.put(BigDecimal.class.getName(), BigDecimal.valueOf(1L));
         container.put(java.lang.Throwable.class.getName(), TypeDefaultValue.DEFAULT_NULL);
         container.put(java.lang.Runnable.class.getName(), TypeDefaultValue.DEFAULT_NULL);
         container.put(Callable.class.getName(), TypeDefaultValue.DEFAULT_NULL);
@@ -46,14 +45,12 @@ public class JdkAnalysisInheritanceTypeValue implements MultiTypeDefaultValue {
         container.put(ThreadGroup.class.getName(), TypeDefaultValue.DEFAULT_NULL);
         container.put(Optional.class.getName(), TypeDefaultValue.DEFAULT_NULL);
         container.put(Charset.class.getName(), StandardCharsets.UTF_8);
-        container.put(TimeZone.class.getName(), TimeZone.getDefault().getID());
+        container.put(TimeZone.class.getName(), TimeZone.getDefault());
         container.put(Appendable.class.getName(), " ");
         //这个很不常见
         container.put(Enumeration.class.getName(), List.of());
 
-        ZonedDateTimeTypeValue zonedDateTimeTypeValue = new ZonedDateTimeTypeValue();
-        Object value = zonedDateTimeTypeValue.getValue(null);
-        container.put(Calendar.class.getName(), value);
+        container.put(Calendar.class.getName(), Calendar.getInstance());
         container.put(Clob.class.getName(), TypeDefaultValue.DEFAULT_NULL);
     }
 

--- a/src/com/github/idea/json/parser/typevalue/jdk/common/multi/JdkBasicTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/common/multi/JdkBasicTypeValue.java
@@ -10,6 +10,7 @@ import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.math.BigInteger;
 import java.net.*;
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.atomic.*;
@@ -72,9 +73,9 @@ public class JdkBasicTypeValue implements MultiTypeDefaultValue {
             container.put("java.net.URI", uri);
         } catch (Exception e) {
         }
-        container.put(Date.class.getName(), DATE_FORMAT.format(new Date()));
-        container.put(java.sql.Date.class.getName(), DATE_FORMAT.format(new Date()));
-        container.put(java.sql.Timestamp.class.getName(), System.currentTimeMillis());
+        container.put(Date.class.getName(), new Date());
+        container.put(java.sql.Date.class.getName(), new java.sql.Date(System.currentTimeMillis()));
+        container.put(java.sql.Timestamp.class.getName(), new Timestamp(System.currentTimeMillis()));
 
         container.put(AtomicBoolean.class.getName(), new AtomicBoolean(true));
         container.put(AtomicReference.class.getName(), TypeDefaultValue.DEFAULT_NULL);
@@ -100,25 +101,21 @@ public class JdkBasicTypeValue implements MultiTypeDefaultValue {
         container.put(WeakReference.class.getName(), TypeDefaultValue.DEFAULT_NULL);
         container.put(SoftReference.class.getName(), TypeDefaultValue.DEFAULT_NULL);
 
-        container.put(UUID.class.getName(), UUID.randomUUID().toString());
+        container.put(UUID.class.getName(), UUID.randomUUID());
 
-        // com.alibaba.fastjson.serializer.SerializeConfig#SerializeConfig(int)
-        container.put(SimpleDateFormat.class.getName(), DATE_FORMAT.toPattern());
+        container.put(SimpleDateFormat.class.getName(), DATE_FORMAT);
         Locale locale = Locale.CHINA;
-        container.put(Locale.class.getName(), locale.toString());
+        container.put(Locale.class.getName(), locale);
 
         Currency currency = Currency.getInstance(locale);
-        container.put(Currency.class.getName(), currency.getCurrencyCode());
-        container.put(InetAddress.class.getName(), "127.0.0.1");
-        container.put(Inet4Address.class.getName(), "127.0.0.1");
-        container.put(Inet6Address.class.getName(), "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
-        Map<String, String> inetSocketAddress = new HashMap<>();
+        container.put(Currency.class.getName(), currency);
+        container.put(InetAddress.class.getName(), TypeDefaultValue.DEFAULT_NULL);
+        container.put(Inet4Address.class.getName(), TypeDefaultValue.DEFAULT_NULL);
+        container.put(Inet6Address.class.getName(), TypeDefaultValue.DEFAULT_NULL);
 
-        inetSocketAddress.put("address", (String) container.get(InetAddress.class.getName()));
-        inetSocketAddress.put("port", "8081");
-        container.put(InetSocketAddress.class.getName(), inetSocketAddress);
+        container.put(InetSocketAddress.class.getName(), TypeDefaultValue.DEFAULT_NULL);
 
-        container.put(Pattern.class.getName(), "^(?![0-9]+$)(?![a-zA-Z]+$)[0-9A-Za-z]{6,12}$");
+        container.put(Pattern.class.getName(),Pattern.compile( "^(?![0-9]+$)(?![a-zA-Z]+$)[0-9A-Za-z]{6,12}$"));
 
 
     }

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/DayOfWeekTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/DayOfWeekTypeValue.java
@@ -15,7 +15,7 @@ public class DayOfWeekTypeValue implements TypeDefaultValue {
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return todayDayOfWeek.toString();
+        return todayDayOfWeek;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/DurationTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/DurationTypeValue.java
@@ -14,7 +14,7 @@ public class DurationTypeValue implements TypeDefaultValue {
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return "1s";
+        return Duration.ofMinutes(1);
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/InstantTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/InstantTypeValue.java
@@ -15,7 +15,7 @@ public class InstantTypeValue implements TypeDefaultValue {
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return now.toString();
+        return now;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/LocalDateTimeTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/LocalDateTimeTypeValue.java
@@ -11,12 +11,11 @@ import java.time.format.DateTimeFormatter;
  * @date 2024/5/19 13:30
  */
 public class LocalDateTimeTypeValue implements TypeDefaultValue {
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private final LocalDateTime now = LocalDateTime.now();
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return now.format(formatter);
+        return now;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/LocalDateTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/LocalDateTypeValue.java
@@ -11,12 +11,11 @@ import java.time.format.DateTimeFormatter;
  * @date 2024/5/19 13:34
  */
 public class LocalDateTypeValue implements TypeDefaultValue {
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private final LocalDate today = LocalDate.now(); // 获取当前日期
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return today.format(formatter);
+        return today;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/LocalTimeTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/LocalTimeTypeValue.java
@@ -12,12 +12,11 @@ import java.time.format.DateTimeFormatter;
  */
 public class LocalTimeTypeValue implements TypeDefaultValue {
 
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
     private final LocalTime now = LocalTime.now();
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return now.format(formatter);
+        return now;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/MonthDayTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/MonthDayTypeValue.java
@@ -11,12 +11,11 @@ import java.time.format.DateTimeFormatter;
  * @date 2024/5/19 13:53
  */
 public class MonthDayTypeValue implements TypeDefaultValue {
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM-dd");
     private final MonthDay now = MonthDay.now();
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return now.format(formatter);
+        return now;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/OffsetDateTimeTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/OffsetDateTimeTypeValue.java
@@ -11,12 +11,11 @@ import java.time.format.DateTimeFormatter;
  * @date 2024/5/19 14:03
  */
 public class OffsetDateTimeTypeValue implements TypeDefaultValue {
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss XXX");
     private final OffsetDateTime now = OffsetDateTime.now();
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return now.format(formatter);
+        return now;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/OffsetTimeTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/OffsetTimeTypeValue.java
@@ -11,12 +11,11 @@ import java.time.format.DateTimeFormatter;
  * @date 2024/5/19 13:56
  */
 public class OffsetTimeTypeValue implements TypeDefaultValue {
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss XXX");
     private final OffsetTime now = OffsetTime.now();
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return now.format(formatter);
+        return now;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/PeriodTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/PeriodTypeValue.java
@@ -15,7 +15,7 @@ public class PeriodTypeValue implements TypeDefaultValue {
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return period.toString();
+        return period;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/YearMonthTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/YearMonthTypeValue.java
@@ -12,13 +12,12 @@ import java.time.format.DateTimeFormatter;
  */
 public class YearMonthTypeValue implements TypeDefaultValue {
 
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
     private final YearMonth now = YearMonth.now();
 
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return now.format(formatter);
+        return now;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/YearTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/YearTypeValue.java
@@ -11,12 +11,11 @@ import java.time.format.DateTimeFormatter;
  * @date 2024/5/19 13:59
  */
 public class YearTypeValue implements TypeDefaultValue {
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy");
     private final Year now = Year.now();
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return now.format(formatter);
+        return now;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/ZoneIdTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/ZoneIdTypeValue.java
@@ -16,7 +16,7 @@ public class ZoneIdTypeValue implements TypeDefaultValue {
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return systemZone.toString();
+        return systemZone;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/ZoneOffsetTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/ZoneOffsetTypeValue.java
@@ -16,7 +16,7 @@ public class ZoneOffsetTypeValue implements TypeDefaultValue {
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return defaultOffset.toString();
+        return defaultOffset;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/jdk/time/ZonedDateTimeTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/jdk/time/ZonedDateTimeTypeValue.java
@@ -13,13 +13,12 @@ import java.time.format.DateTimeFormatter;
  */
 public class ZonedDateTimeTypeValue implements TypeDefaultValue {
 
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z");
     private final ZonedDateTime now = ZonedDateTime.now();
 
 
     @Override
     public Object getValue(TypeValueContext context) {
-        return now.format(formatter);
+        return now;
     }
 
     @Override

--- a/src/com/github/idea/json/parser/typevalue/thirdlib/jackson/JacksonAllPackageTypeValue.java
+++ b/src/com/github/idea/json/parser/typevalue/thirdlib/jackson/JacksonAllPackageTypeValue.java
@@ -1,9 +1,12 @@
 package com.github.idea.json.parser.typevalue.thirdlib.jackson;
 
+import com.fasterxml.jackson.databind.node.*;
 import com.github.idea.json.parser.typevalue.MultiTypeDefaultValue;
 import com.github.idea.json.parser.typevalue.TypeValueContext;
 import com.intellij.psi.PsiType;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,19 +28,19 @@ public class JacksonAllPackageTypeValue implements MultiTypeDefaultValue {
 
     public void init() {
         Map<String, Object> container = this.getContainer();
-        container.put("com.fasterxml.jackson.databind.node.BooleanNode", true);
+        container.put("com.fasterxml.jackson.databind.node.BooleanNode", BooleanNode.valueOf(true));
         container.put("com.fasterxml.jackson.databind.node.ArrayNode", List.of());
-        container.put("com.fasterxml.jackson.databind.node.BigIntegerNode", "0");
-        container.put("com.fasterxml.jackson.databind.node.DecimalNode", 0.0);
-        container.put("com.fasterxml.jackson.databind.node.DoubleNode", 0.0D);
-        container.put("com.fasterxml.jackson.databind.node.FloatNode", 0.0F);
-        container.put("com.fasterxml.jackson.databind.node.IntNode", 0);
-        container.put("com.fasterxml.jackson.databind.node.LongNode", 0L);
-        container.put("com.fasterxml.jackson.databind.node.NullNode", null);
-        container.put("com.fasterxml.jackson.databind.node.NumericNode", 0);
+        container.put("com.fasterxml.jackson.databind.node.BigIntegerNode", BigIntegerNode.valueOf(BigInteger.ONE));
+        container.put("com.fasterxml.jackson.databind.node.DecimalNode", DecimalNode.valueOf(BigDecimal.ONE));
+        container.put("com.fasterxml.jackson.databind.node.DoubleNode", DoubleNode.valueOf(1d));
+        container.put("com.fasterxml.jackson.databind.node.FloatNode", FloatNode.valueOf(1f));
+        container.put("com.fasterxml.jackson.databind.node.IntNode", IntNode.valueOf(1));
+        container.put("com.fasterxml.jackson.databind.node.LongNode", LongNode.valueOf(1L));
+        container.put("com.fasterxml.jackson.databind.node.NullNode", NullNode.getInstance());
+        container.put("com.fasterxml.jackson.databind.node.NumericNode", IntNode.valueOf(1));
         container.put("com.fasterxml.jackson.databind.node.POJONode", Map.of());
-        container.put("com.fasterxml.jackson.databind.node.ShortNode", 0);
-        container.put("com.fasterxml.jackson.databind.node.TextNode", " ");
+        container.put("com.fasterxml.jackson.databind.node.ShortNode", ShortNode.valueOf((short) 1));
+        container.put("com.fasterxml.jackson.databind.node.TextNode", TextNode.valueOf(" "));
     }
 
     @Override

--- a/src/com/github/wangji92/arthas/plugin/ui/ArthasVmToolComplexDialog.java
+++ b/src/com/github/wangji92/arthas/plugin/ui/ArthasVmToolComplexDialog.java
@@ -1,6 +1,5 @@
 package com.github.wangji92.arthas.plugin.ui;
 
-import com.github.idea.json.parser.PsiParserToJson;
 import com.github.wangji92.arthas.plugin.common.command.CommandContext;
 import com.github.wangji92.arthas.plugin.utils.ActionLinkUtils;
 import com.intellij.openapi.diagnostic.Logger;
@@ -99,7 +98,7 @@ public class ArthasVmToolComplexDialog extends JDialog {
                     //PsiElement declarationScope = parameter.getDeclarationScope();
                     String jsonString ="";
                     try {
-                        jsonString = PsiParserToJson.getInstance().toJSONString(parameter);
+                       // jsonString = PsiParserToJson.getInstance().toJSONString(parameter);
                     } catch (Exception e) {
                         LOG.error("error",e);
                     }

--- a/src/com/github/wangji92/arthas/plugin/utils/OgnlJsonHandlerUtils.java
+++ b/src/com/github/wangji92/arthas/plugin/utils/OgnlJsonHandlerUtils.java
@@ -125,8 +125,8 @@ public class OgnlJsonHandlerUtils {
             case "java.util.regex.Pattern" -> "(#p=@java.util.regex.Pattern@compile(\"^(?![0-9]+$)(?![a-zA-Z]+$)[0-9A-Za-z]{6,12}$\"),#p)";
             case "java.lang.Throwable","java.lang.RuntimeException" -> "(#p=new java.lang.RuntimeException(\"message\"),#p)";
             case "java.nio.charset.Charset" -> "(#p=@java.nio.charset.StandardCharsets@UTF_8,#p)";
-            case "java.util.TimeZone" -> "(#p=@java.util.TimeZone@getDefault().getID(),#p)";
-            case "java.util.Calendar" -> "(#p=java.util.Calendar.getInstance(),#p)";
+            case "java.util.TimeZone" -> "(#p=@java.util.TimeZone@getDefault(),#p)";
+            case "java.util.Calendar" -> "(#p=@java.util.Calendar@getInstance(),#p)";
             case "java.time.DayOfWeek" -> "(#p=@java.time.LocalDate@now().getDayOfWeek(),#p)";
             case "java.time.Duration" -> "(#p=@java.time.Duration@ofHours(1L),#p)";
             case "java.time.Instant" -> "(#p=@java.time.Instant@now(),#p)";

--- a/src/com/github/wangji92/arthas/plugin/utils/OgnlJsonHandlerUtils.java
+++ b/src/com/github/wangji92/arthas/plugin/utils/OgnlJsonHandlerUtils.java
@@ -1,6 +1,7 @@
 package com.github.wangji92.arthas.plugin.utils;
 
 import com.github.idea.json.parser.PsiParserToJson;
+import com.github.idea.json.parser.toolkit.ParserContext;
 import com.github.idea.json.parser.toolkit.PsiToolkit;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiClassType;
@@ -25,11 +26,21 @@ public class OgnlJsonHandlerUtils {
             public String getTemplate() {
                 return "@com.alibaba.fastjson.JSON@parseObject(\"%s\",%s)";
             }
+
+            @Override
+            public ParserContext.ParserJsonType getType() {
+                return ParserContext.ParserJsonType.FASTJSON;
+            }
         },
         FASTJSON_2 {
             @Override
             public String getTemplate() {
                 return "@com.alibaba.fastjson2.JSON@parseObject(\"%s\",%s)";
+            }
+
+            @Override
+            public ParserContext.ParserJsonType getType() {
+                return ParserContext.ParserJsonType.FASTJSON_2;
             }
         },
         JACKSON {
@@ -37,11 +48,21 @@ public class OgnlJsonHandlerUtils {
             public String getTemplate() {
                 return "new com.fasterxml.jackson.databind.ObjectMapper().readValue(\"%s\",%s)";
             }
+
+            @Override
+            public ParserContext.ParserJsonType getType() {
+                return ParserContext.ParserJsonType.JACKSON;
+            }
         },
         GSON {
             @Override
             public String getTemplate() {
                 return "new com.google.gson.Gson().fromJson(\"%s\",%s)";
+            }
+
+            @Override
+            public ParserContext.ParserJsonType getType() {
+                return ParserContext.ParserJsonType.GSON;
             }
         };
 
@@ -52,6 +73,8 @@ public class OgnlJsonHandlerUtils {
          * @return
          */
         public abstract String getTemplate();
+
+        public abstract ParserContext.ParserJsonType getType();
     }
 
     /**
@@ -90,30 +113,40 @@ public class OgnlJsonHandlerUtils {
 
     /**
      * 获取这些基本类型的ognl 表达式
+     *
      * @param psiType
      * @return
      */
     public static String getPsiClassJDKBaseTypeDefaultOgnl(PsiType psiType) {
         String canonicalText = PsiToolkit.getPsiTypeSimpleName(psiType);
         return switch (canonicalText) {
-            case "java.lang.StringBuilder","java.lang.StringBuffer" -> "(#p=new "+psiType.getCanonicalText()+"(),#p.append(\" \"),#p)";
+            case "java.lang.StringBuilder", "java.lang.StringBuffer" ->
+                    "(#p=new " + psiType.getCanonicalText() + "(),#p.append(\" \"),#p)";
             case "java.math.BigInteger" -> "(#p=new java.math.BigInteger(\"0\"),#p)";
             case "java.math.BigDecimal" -> "(#p=@java.math.BigDecimal@valueOf(1L),#p)";
-            case "java.net.URL","java.net.URI" -> "(#p=new "+psiType.getCanonicalText()+"(\"https://arthas.aliyun.com\"),#p)";
+            case "java.net.URL", "java.net.URI" ->
+                    "(#p=new " + psiType.getCanonicalText() + "(\"https://arthas.aliyun.com\"),#p)";
             case "java.util.Date" -> "(#p=new java.util.Date(),#p)";
             case "java.sql.Date" -> "(#p=new java.sql.Date(@java.lang.System@currentTimeMillis()),#p)";
             case "java.sql.Timestamp" -> "(#p=new java.sql.Timestamp(@java.lang.System@currentTimeMillis()),#p)";
-            case "java.util.concurrent.atomic.AtomicBoolean" -> "(#p=new java.util.concurrent.atomic.AtomicBoolean(true),#p)";
-            case "java.util.concurrent.atomic.AtomicInteger" -> "(#p=new java.util.concurrent.atomic.AtomicInteger(1),#p)";
+            case "java.util.concurrent.atomic.AtomicBoolean" ->
+                    "(#p=new java.util.concurrent.atomic.AtomicBoolean(true),#p)";
+            case "java.util.concurrent.atomic.AtomicInteger" ->
+                    "(#p=new java.util.concurrent.atomic.AtomicInteger(1),#p)";
             case "java.util.concurrent.atomic.AtomicLong" -> "(#p=new java.util.concurrent.atomic.AtomicLong(1L),#p)";
-            case "java.util.concurrent.atomic.AtomicIntegerArray" -> "(#p=new java.util.concurrent.atomic.AtomicIntegerArray(1),#p.set(0,1),#p)";
-            case "java.util.concurrent.atomic.DoubleAdder" -> "(#p=new java.util.concurrent.atomic.DoubleAdder(),#p.add(1.0d),#p)";
-            case "java.util.concurrent.atomic.LongAdder" -> "(#p=new java.util.concurrent.atomic.LongAdder(),#p.add(1L),#p)";
+            case "java.util.concurrent.atomic.AtomicIntegerArray" ->
+                    "(#p=new java.util.concurrent.atomic.AtomicIntegerArray(1),#p.set(0,1),#p)";
+            case "java.util.concurrent.atomic.DoubleAdder" ->
+                    "(#p=new java.util.concurrent.atomic.DoubleAdder(),#p.add(1.0d),#p)";
+            case "java.util.concurrent.atomic.LongAdder" ->
+                    "(#p=new java.util.concurrent.atomic.LongAdder(),#p.add(1L),#p)";
             case "java.util.concurrent.atomic.AtomicReference" -> "(#p=null,#p)";
-            case "java.lang.Object","java.lang.Runnable","java.util.concurrent.Callable","java.util.concurrent.Future","java.lang.Thread","java.lang.ThreadGroup","java.util.Optional" -> "(#p=null,#p)";
+            case "java.lang.Object", "java.lang.Runnable", "java.util.concurrent.Callable",
+                 "java.util.concurrent.Future", "java.lang.Thread", "java.lang.ThreadGroup", "java.util.Optional" ->
+                    "(#p=null,#p)";
             case "java.lang.Enum" -> "(#p=null,#p)";
             case "java.lang.ref.WeakReference" -> "(#p=null,#p)";
-            case "java.lang.ref.SoftReference","java.sql.Clob" -> "(#p=null,#p)";
+            case "java.lang.ref.SoftReference", "java.sql.Clob" -> "(#p=null,#p)";
             case "java.util.UUID" -> "(#p=@java.util.UUID@randomUUID(),#p)";
             case "java.text.SimpleDateFormat" -> "(#p=new java.text.SimpleDateFormat(\"yyyy-MM-dd HH:mm:ss\"),#p)";
             case "java.text.DateFormat" -> "(#p=new java.text.SimpleDateFormat(\"yyyy-MM-dd HH:mm:ss\"),#p)";
@@ -121,9 +154,12 @@ public class OgnlJsonHandlerUtils {
             case "java.util.Currency" -> "(#p=@java.util.Currency@getInstance(@java.util.Locale@CHINA),#p)";
             case "java.net.InetAddress" -> "(#p=@java.net.InetAddress@getByName(\"127.0.0.1\"),#p)";
             case "java.net.Inet4Address" -> "(#p=@java.net.InetAddress@getByName(\"127.0.0.1\"),#p)";
-            case "java.net.Inet6Address" -> "(#p=@java.net.Inet6Address@Inet6Address(\"2001:0db8:85a3:0000:0000:8a2e:0370:7334\"),#p)";
-            case "java.util.regex.Pattern" -> "(#p=@java.util.regex.Pattern@compile(\"^(?![0-9]+$)(?![a-zA-Z]+$)[0-9A-Za-z]{6,12}$\"),#p)";
-            case "java.lang.Throwable","java.lang.RuntimeException" -> "(#p=new java.lang.RuntimeException(\"message\"),#p)";
+            case "java.net.Inet6Address" ->
+                    "(#p=@java.net.Inet6Address@Inet6Address(\"2001:0db8:85a3:0000:0000:8a2e:0370:7334\"),#p)";
+            case "java.util.regex.Pattern" ->
+                    "(#p=@java.util.regex.Pattern@compile(\"^(?![0-9]+$)(?![a-zA-Z]+$)[0-9A-Za-z]{6,12}$\"),#p)";
+            case "java.lang.Throwable", "java.lang.RuntimeException" ->
+                    "(#p=new java.lang.RuntimeException(\"message\"),#p)";
             case "java.nio.charset.Charset" -> "(#p=@java.nio.charset.StandardCharsets@UTF_8,#p)";
             case "java.util.TimeZone" -> "(#p=@java.util.TimeZone@getDefault(),#p)";
             case "java.util.Calendar" -> "(#p=@java.util.Calendar@getInstance(),#p)";
@@ -176,16 +212,22 @@ public class OgnlJsonHandlerUtils {
 
         //如果基本类型可以处理，不需要走json 字符串去处理了
         String psiClassJDKBaseTypeDefaultOgnl = getPsiClassJDKBaseTypeDefaultOgnl(currentPsiType);
-        if(psiClassJDKBaseTypeDefaultOgnl !=null){
+        if (psiClassJDKBaseTypeDefaultOgnl != null) {
             return psiClassJDKBaseTypeDefaultOgnl;
         }
-
-        String jsonString = PsiParserToJson.getInstance().toJSONString(currentPsiType, false);
-        String escapeJson = StringEscapeUtils.escapeJson(jsonString);
         JsonType jsonType = getJsonType(project);
         if (jsonType == null) {
             return null;
         }
+
+        // 根据ognl的json 类型 处理具体的类型
+        ParserContext parserContext = new ParserContext();
+        parserContext.setPretty(false);
+        parserContext.setJsonType(jsonType.getType());
+
+        String jsonString = PsiParserToJson.getInstance().toJSONString(currentPsiType, parserContext);
+        String escapeJson = StringEscapeUtils.escapeJson(jsonString);
+
         String psiTypeSimpleName = PsiToolkit.getPsiTypeQualifiedNameClazzName((PsiClassType) currentPsiType);
         return jsonType.getTemplate().formatted(escapeJson, "@" + psiTypeSimpleName + "@class");
     }


### PR DESCRIPTION
- 最早之前实现默认是参考了FastJson 的序列化结果生成的字符串，比如 `Calendar` 生成一个时间字符串，然后通过Gson 序列化为一个字符串，但是这个有一个缺陷，不同的JSON 序列化工具有时候不一样，有时候不支持怎么办？ 
如果发现 工程有FastJson ，就用fastjson 构造 ognl 表达式，同时也使用 fastjson 进行序列化 parseJson 最后的对象，这里就对于 `Calendar` 不直接生成字符串了，直接创建一个对象进去，至于序列化成什么样子，当前的工具说了算。增强了准确性，但是这个也不是100%，对于一些特殊类型的对象序列化不同的JSON 序列化工具支持默认支持程度不一样，有的需要特殊的配置。

- 对于一个JDK 基本参数类型直接返回Ognl 表达式，无需使用JSON进行序列化了
```bash
(#p=@java.util.UUID@randomUUID(),#p)
```
- 对于方法上使用Copy JSON，构造函数生成当前clazz的json ，其他的情况生成返回值的json 

